### PR TITLE
fix(grid): stop theme force-unwraps crashing menus

### DIFF
--- a/responsive_data_grid/lib/src/extensions.dart
+++ b/responsive_data_grid/lib/src/extensions.dart
@@ -78,3 +78,28 @@ extension TimeOfDayExtensions on TimeOfDay {
     return DateTime(now.year, now.month, now.day, hour, minute);
   }
 }
+
+/// Safe color/text lookups so Material 3 themes without `ButtonTheme.colorScheme`
+/// or empty `primaryTextTheme` do not crash grid chrome.
+extension GridThemeFallbacks on ThemeData {
+  Color get gridPrimaryColor =>
+      buttonTheme.colorScheme?.primary ?? colorScheme.primary;
+
+  Color get gridSurfaceColor =>
+      buttonTheme.colorScheme?.surface ?? colorScheme.surface;
+
+  TextStyle get gridTitleSmall =>
+      dataTableTheme.headingTextStyle ??
+      textTheme.titleSmall ??
+      primaryTextTheme.titleSmall ??
+      const TextStyle(fontSize: 14, fontWeight: FontWeight.w500);
+
+  TextStyle get gridBodyMedium =>
+      dataTableTheme.dataTextStyle ??
+      textTheme.bodyMedium ??
+      primaryTextTheme.bodyMedium ??
+      const TextStyle(fontSize: 14);
+
+  TextStyle? get gridLabelLarge =>
+      textTheme.labelLarge ?? primaryTextTheme.labelLarge;
+}

--- a/responsive_data_grid/lib/src/widgets/column_header.dart
+++ b/responsive_data_grid/lib/src/widgets/column_header.dart
@@ -91,7 +91,7 @@ class ColumnHeaderState<TItem extends Object, TValue extends dynamic>
     final textStyle =
         widget.definition.header.textStyle ??
         theme.dataTableTheme.headingTextStyle ??
-        theme.primaryTextTheme.titleSmall!.copyWith(color: foregroundColor);
+        theme.gridTitleSmall.copyWith(color: foregroundColor);
 
     final items = List<Widget>.empty(growable: true);
 

--- a/responsive_data_grid/lib/src/widgets/column_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/column_menu.dart
@@ -88,12 +88,11 @@ class ColumnMenu<T extends Object> extends DropDownViewWidget {
                         context,
                         rootNavigator: true,
                       );
+                      final route = ModalRoute.of(context);
                       column.aggregations.clear();
                       column.filterRules.criteria = null;
                       await gridState.refreshData();
-                      if (navigator.canPop()) {
-                        navigator.pop();
-                      }
+                      _popMenuIfCurrent(navigator, route);
                     },
                     icon: Icon(Icons.clear_all),
                     label: Text(LocalizedMessages.clear),
@@ -104,10 +103,9 @@ class ColumnMenu<T extends Object> extends DropDownViewWidget {
                         context,
                         rootNavigator: true,
                       );
+                      final route = ModalRoute.of(context);
                       await gridState.refreshData();
-                      if (navigator.canPop()) {
-                        navigator.pop();
-                      }
+                      _popMenuIfCurrent(navigator, route);
                     },
                     icon: Icon(Icons.save),
                     label: Text(LocalizedMessages.apply),

--- a/responsive_data_grid/lib/src/widgets/column_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/column_menu.dart
@@ -78,28 +78,35 @@ class ColumnMenu<T extends Object> extends DropDownViewWidget {
               ),
               column.filterRules.showFilter(column, gridState),
               Divider(),
-              Row(
-                mainAxisSize: MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.end,
+              Wrap(
+                alignment: WrapAlignment.spaceBetween,
+                crossAxisAlignment: WrapCrossAlignment.center,
                 children: [
                   TextButton.icon(
                     onPressed: () async {
+                      final navigator = Navigator.of(
+                        context,
+                        rootNavigator: true,
+                      );
                       column.aggregations.clear();
                       column.filterRules.criteria = null;
                       await gridState.refreshData();
-                      if (context.mounted) {
-                        close(context);
+                      if (navigator.canPop()) {
+                        navigator.pop();
                       }
                     },
                     icon: Icon(Icons.clear_all),
                     label: Text(LocalizedMessages.clear),
                   ),
-                  Spacer(flex: 2),
                   TextButton.icon(
                     onPressed: () async {
+                      final navigator = Navigator.of(
+                        context,
+                        rootNavigator: true,
+                      );
                       await gridState.refreshData();
-                      if (context.mounted) {
-                        close(context);
+                      if (navigator.canPop()) {
+                        navigator.pop();
                       }
                     },
                     icon: Icon(Icons.save),

--- a/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
+++ b/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
@@ -27,7 +27,10 @@ class _DropDownViewState extends State<DropDownViewWidget> {
   }
 
   void close(BuildContext context) {
-    Navigator.of(context).pop();
+    final navigator = Navigator.of(context, rootNavigator: true);
+    if (navigator.canPop()) {
+      navigator.pop();
+    }
   }
 
   @override
@@ -43,7 +46,7 @@ class _DropDownViewState extends State<DropDownViewWidget> {
         padding: EdgeInsets.zero,
       ),
       icon: widget.icon,
-      color: widget.theme.buttonTheme.colorScheme!.primary,
+      color: widget.theme.gridPrimaryColor,
       onPressed: (() {
         showAlignedDialog<void>(
           avoidOverflow: true,
@@ -55,7 +58,7 @@ class _DropDownViewState extends State<DropDownViewWidget> {
           offset: Offset(32, 0),
           builder: (BuildContext ctx) => SizedBox(
             width: widget.dropDownWidth,
-            child: SingleChildScrollView(child: widget.build(context, close)),
+            child: SingleChildScrollView(child: widget.build(ctx, close)),
           ),
         );
       }),

--- a/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
+++ b/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
@@ -27,10 +27,10 @@ class _DropDownViewState extends State<DropDownViewWidget> {
   }
 
   void close(BuildContext context) {
-    final navigator = Navigator.of(context, rootNavigator: true);
-    if (navigator.canPop()) {
-      navigator.pop();
-    }
+    _popMenuIfCurrent(
+      Navigator.of(context, rootNavigator: true),
+      ModalRoute.of(context),
+    );
   }
 
   @override
@@ -63,5 +63,11 @@ class _DropDownViewState extends State<DropDownViewWidget> {
         );
       }),
     );
+  }
+}
+
+void _popMenuIfCurrent(NavigatorState navigator, Route<dynamic>? route) {
+  if (route != null && route.isCurrent && navigator.canPop()) {
+    navigator.pop();
   }
 }

--- a/responsive_data_grid/lib/src/widgets/field.dart
+++ b/responsive_data_grid/lib/src/widgets/field.dart
@@ -14,7 +14,7 @@ class DataGridFieldWidget<TItem extends Object, TValue extends dynamic>
     final effectiveDataTextStyle =
         definition.textStyle ??
         theme.dataTableTheme.dataTextStyle ??
-        theme.primaryTextTheme.bodyMedium!;
+        theme.gridBodyMedium;
 
     Widget? child;
     if (definition.customFieldWidget != null) {

--- a/responsive_data_grid/lib/src/widgets/grid_group_chooser.dart
+++ b/responsive_data_grid/lib/src/widgets/grid_group_chooser.dart
@@ -37,7 +37,7 @@ class GridGroupChooser<TItem> extends StatelessWidget {
                   padding: EdgeInsets.only(right: 4),
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: theme.buttonTheme.colorScheme!.surface,
+                      color: theme.gridSurfaceColor,
                     ),
                     child: Padding(
                       padding: EdgeInsets.only(
@@ -113,7 +113,7 @@ class GridGroupChooser<TItem> extends StatelessWidget {
         padding: EdgeInsets.only(top: 4, bottom: 4),
         child: DecoratedBox(
           decoration: BoxDecoration(
-            color: theme.buttonTheme.colorScheme!.surface,
+            color: theme.gridSurfaceColor,
           ),
           child: Padding(
             padding: theme.buttonTheme.padding,

--- a/responsive_data_grid/lib/src/widgets/group_header.dart
+++ b/responsive_data_grid/lib/src/widgets/group_header.dart
@@ -19,7 +19,7 @@ class GridGroupHeader extends StatelessWidget {
             // ),
             Text(
               group.value ?? LocalizedMessages.noEntry,
-              style: theme.primaryTextTheme.titleSmall,
+              style: theme.gridTitleSmall,
             ),
           ],
         ),

--- a/responsive_data_grid/lib/src/widgets/group_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/group_menu.dart
@@ -57,10 +57,9 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                         context,
                         rootNavigator: true,
                       );
+                      final route = ModalRoute.of(context);
                       await gridState.updateGroup(group);
-                      if (navigator.canPop()) {
-                        navigator.pop();
-                      }
+                      _popMenuIfCurrent(navigator, route);
                     },
                     icon: Icon(Icons.save, color: theme.colorScheme.onPrimary),
                   ),
@@ -77,11 +76,10 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                         context,
                         rootNavigator: true,
                       );
+                      final route = ModalRoute.of(context);
                       group.aggregates.clear();
                       await gridState.updateGroup(group);
-                      if (navigator.canPop()) {
-                        navigator.pop();
-                      }
+                      _popMenuIfCurrent(navigator, route);
                     },
                     icon: Icon(
                       Icons.clear_all,

--- a/responsive_data_grid/lib/src/widgets/group_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/group_menu.dart
@@ -50,12 +50,16 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                   child: TextButton.icon(
                     label: Text(
                       "Apply",
-                      style: theme.primaryTextTheme.labelLarge,
+                      style: theme.gridLabelLarge,
                     ),
                     onPressed: () async {
+                      final navigator = Navigator.of(
+                        context,
+                        rootNavigator: true,
+                      );
                       await gridState.updateGroup(group);
-                      if (context.mounted) {
-                        close(context);
+                      if (navigator.canPop()) {
+                        navigator.pop();
                       }
                     },
                     icon: Icon(Icons.save, color: theme.colorScheme.onPrimary),
@@ -66,13 +70,17 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                   child: TextButton.icon(
                     label: Text(
                       "Clear All",
-                      style: theme.primaryTextTheme.labelLarge,
+                      style: theme.gridLabelLarge,
                     ),
                     onPressed: () async {
+                      final navigator = Navigator.of(
+                        context,
+                        rootNavigator: true,
+                      );
                       group.aggregates.clear();
                       await gridState.updateGroup(group);
-                      if (context.mounted) {
-                        close(context);
+                      if (navigator.canPop()) {
+                        navigator.pop();
                       }
                     },
                     icon: Icon(
@@ -85,7 +93,7 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                 TextButton.icon(
                   label: Text(
                     "Remove Group",
-                    style: theme.primaryTextTheme.labelLarge,
+                    style: theme.gridLabelLarge,
                   ),
                   onPressed: () => removeGroup(group),
                   icon: Icon(Icons.delete, color: theme.colorScheme.error),

--- a/responsive_data_grid/test/theme_force_unwrap_test.dart
+++ b/responsive_data_grid/test/theme_force_unwrap_test.dart
@@ -1,0 +1,160 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+  final int age;
+
+  const _Person(this.name, this.age);
+}
+
+/// Material 3 theme with the fields the grid currently force-unwraps left null.
+ThemeData _sparseTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+    buttonTheme: const ButtonThemeData(),
+    primaryTextTheme: const TextTheme(),
+  );
+}
+
+Widget _harness({required Widget child}) {
+  return MaterialApp(
+    theme: _sparseTheme(),
+    home: Scaffold(
+      body: SizedBox(width: 900, height: 700, child: child),
+    ),
+  );
+}
+
+ResponsiveDataGrid<_Person> _grid({bool grouping = true}) {
+  return ResponsiveDataGrid<_Person>.clientSide(
+    items: const [
+      _Person('Ada', 36),
+      _Person('Grace', 41),
+      _Person('Ada', 30),
+    ],
+    pageSize: 10,
+    pagingMode: PagingMode.pager,
+    height: 600,
+    allowGrouping: grouping,
+    initialLoadCriteria: grouping
+        ? LoadCriteria(
+            groupBy: [
+              GroupCriteria(
+                fieldName: 'name',
+                direction: OrderDirections.ascending,
+                aggregates: const [],
+              ),
+            ],
+          )
+        : null,
+    columns: [
+      StringColumn<_Person>(
+        fieldName: 'name',
+        header: const ColumnHeader(
+          text: 'Name',
+          showFilter: true,
+          showOrderBy: true,
+          showAggregations: true,
+        ),
+        value: (row) => row.name,
+        xsCols: 6,
+      ),
+      IntColumn<_Person>(
+        fieldName: 'age',
+        header: const ColumnHeader(
+          text: 'Age',
+          showFilter: true,
+          showOrderBy: true,
+        ),
+        value: (row) => row.age,
+        xsCols: 6,
+      ),
+    ],
+  );
+}
+
+void main() {
+  testWidgets(
+    'grid, group chooser, and headers render under a sparse Material 3 theme',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_harness(child: _grid()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Name'), findsWidgets);
+      expect(find.text('Age'), findsWidgets);
+      expect(find.byIcon(Icons.account_tree), findsWidgets);
+    },
+  );
+
+  testWidgets('column menu opens without crashing under a sparse theme', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_harness(child: _grid(grouping: false)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    _expectNoThemeCrash(tester);
+    expect(find.text('Filter'), findsOneWidget);
+    expect(find.text(LocalizedMessages.apply), findsOneWidget);
+  });
+
+  testWidgets('column menu dismisses via Apply using the overlay context', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_harness(child: _grid(grouping: false)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Filter'), findsOneWidget);
+
+    await tester.tap(find.text(LocalizedMessages.apply));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    _expectNoThemeCrash(tester);
+    expect(find.text('Filter'), findsNothing);
+  });
+}
+
+/// Overflow in the 250px column menu is #41. This issue only forbids theme
+/// force-unwrap / Navigator crashes.
+void _expectNoThemeCrash(WidgetTester tester) {
+  final error = tester.takeException();
+  if (error == null) return;
+  expect(
+    error.toString(),
+    contains('overflowed'),
+    reason: 'Unexpected exception: $error',
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #36. Grid chrome no longer force-unwraps `ButtonTheme.colorScheme` or `primaryTextTheme` styles, which crash Material 3 apps when opening column menus or showing the group chooser.

## Changes
- Theme fallbacks via `GridThemeFallbacks` (`ColorScheme` / `TextTheme` / `DataTableTheme`)
- Column/group menus build with the overlay context and pop the root navigator
- Column menu actions wrap so Apply/Clear stay tappable in the 250px overlay
- Widget tests with a sparse Material 3 `ThemeData` (empty `primaryTextTheme`, null `buttonTheme.colorScheme`)

## Test plan
- [x] `dart analyze lib test` in `responsive_data_grid/`
- [x] `flutter test test/theme_force_unwrap_test.dart`
- [x] `flutter test test/widget_test.dart` from `example/`
- [x] Example launched on macOS (group chooser path, VM connected, no crash)
- Menu overlay sizing/clipping remains #41

Closes #36