### PR TITLE
fix(grid): stop Expanded inside unbounded Columns

### DIFF
--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -268,13 +268,13 @@ class ResponsiveDataGridState<TItem extends Object>
                 );
 
                 if (isLoading) {
+                  final spinner = const Center(
+                    child: CircularProgressIndicator(),
+                  );
                   parts.add(
-                    Column(
-                      mainAxisSize: MainAxisSize.max,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [CircularProgressIndicator()],
-                    ),
+                    constraints.hasBoundedHeight
+                        ? Expanded(child: spinner)
+                        : spinner,
                   );
                 } else {
                   parts.add(

--- a/responsive_data_grid/lib/src/widgets/body.dart
+++ b/responsive_data_grid/lib/src/widgets/body.dart
@@ -18,7 +18,11 @@ class GridBody<TItem extends Object> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(child: getBody());
+    final body = getBody();
+    if (constraints.hasBoundedHeight) {
+      return Expanded(child: body);
+    }
+    return body;
   }
 
   Widget getBody() {
@@ -28,6 +32,7 @@ class GridBody<TItem extends Object> extends StatelessWidget {
       return ResponsiveDataGridPagedBodyWidget<TItem>(
         gridState: gridState,
         theme: gridTheme,
+        shrinkWrap: !constraints.hasBoundedHeight,
       );
     } else {
       return ResponsiveGridInfiniteScrollBodyWidget<TItem>(

--- a/responsive_data_grid/lib/src/widgets/paged_body.dart
+++ b/responsive_data_grid/lib/src/widgets/paged_body.dart
@@ -20,7 +20,12 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
       return gridState.widget.noResults ?? const Text("No results found.");
     }
     if (pageData.groups.isNotEmpty) {
-      return buildGroups(pageData, pageData.groups, pageData.items);
+      return buildGroups(
+        pageData,
+        pageData.groups,
+        pageData.items,
+        nested: false,
+      );
     }
     return getPage(pageData.items);
   }
@@ -28,15 +33,20 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
   Widget buildGroups(
     ListResponse<TItem> response,
     List<GroupResult> groups,
-    List<TItem> items,
-  ) {
+    List<TItem> items, {
+    required bool nested,
+  }) {
     final col = gridState.widget.columns.firstWhere(
       (c) => c.fieldName == groups.first.fieldName,
     );
 
+    // Nested group lists live inside a Column, so they must always shrink-wrap.
+    // Only the top-level groups list may scroll when the grid has a bounded height.
+    final wrap = nested || shrinkWrap;
+
     return ListView.builder(
-      shrinkWrap: shrinkWrap,
-      physics: shrinkWrap ? const NeverScrollableScrollPhysics() : null,
+      shrinkWrap: wrap,
+      physics: wrap ? const NeverScrollableScrollPhysics() : null,
       itemBuilder: (context, index) {
         final group = groups[index];
 
@@ -54,7 +64,12 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
               ),
               child: group.subGroups.isEmpty
                   ? getPage(groupItems)
-                  : buildGroups(response, group.subGroups, groupItems),
+                  : buildGroups(
+                      response,
+                      group.subGroups,
+                      groupItems,
+                      nested: true,
+                    ),
             ),
             GridGroupFooter<TItem>(
               group: group,

--- a/responsive_data_grid/lib/src/widgets/paged_body.dart
+++ b/responsive_data_grid/lib/src/widgets/paged_body.dart
@@ -4,24 +4,25 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
     extends StatelessWidget {
   final ResponsiveDataGridState<TItem> gridState;
   final ThemeData theme;
+  final bool shrinkWrap;
 
   const ResponsiveDataGridPagedBodyWidget({
     super.key,
     required this.gridState,
     required this.theme,
+    this.shrinkWrap = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    Widget child;
-    final pageData = gridState._dataCache.pageMap[gridState.pageNumber]!;
-    if (pageData.groups.isNotEmpty) {
-      child = buildGroups(pageData, pageData.groups, pageData.items);
-    } else {
-      child = getPage(pageData.items);
+    final pageData = gridState._dataCache.pageMap[gridState.pageNumber];
+    if (pageData == null) {
+      return gridState.widget.noResults ?? const Text("No results found.");
     }
-
-    return child;
+    if (pageData.groups.isNotEmpty) {
+      return buildGroups(pageData, pageData.groups, pageData.items);
+    }
+    return getPage(pageData.items);
   }
 
   Widget buildGroups(
@@ -34,6 +35,8 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
     );
 
     return ListView.builder(
+      shrinkWrap: shrinkWrap,
+      physics: shrinkWrap ? const NeverScrollableScrollPhysics() : null,
       itemBuilder: (context, index) {
         final group = groups[index];
 
@@ -46,7 +49,9 @@ class ResponsiveDataGridPagedBodyWidget<TItem extends Object>
           children: [
             GridGroupHeader(group: group, theme: theme),
             Padding(
-              padding: EdgeInsets.only(left: 15),
+              padding: EdgeInsets.only(
+                left: gridState.widget.groupIndent.toDouble(),
+              ),
               child: group.subGroups.isEmpty
                   ? getPage(groupItems)
                   : buildGroups(response, group.subGroups, groupItems),

--- a/responsive_data_grid/test/layout_constraints_test.dart
+++ b/responsive_data_grid/test/layout_constraints_test.dart
@@ -1,3 +1,4 @@
+import 'package:client_filtering/client_filtering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:responsive_data_grid/responsive_data_grid.dart';
@@ -91,4 +92,70 @@ void main() {
     expect(find.text('Ada'), findsWidgets);
     expect(find.byType(Expanded), findsWidgets);
   });
+
+  testWidgets(
+    'bounded-height nested groups do not throw unbounded nested ListViews',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.clientSide(
+                items: const [
+                  _Person('Ada', 36),
+                  _Person('Ada', 30),
+                  _Person('Grace', 41),
+                ],
+                pageSize: 10,
+                pagingMode: PagingMode.pager,
+                height: 600,
+                allowGrouping: true,
+                initialLoadCriteria: LoadCriteria(
+                  groupBy: [
+                    GroupCriteria(
+                      fieldName: 'name',
+                      direction: OrderDirections.ascending,
+                      aggregates: const [],
+                    ),
+                    GroupCriteria(
+                      fieldName: 'age',
+                      direction: OrderDirections.ascending,
+                      aggregates: const [],
+                    ),
+                  ],
+                ),
+                columns: [
+                  StringColumn<_Person>(
+                    fieldName: 'name',
+                    header: const ColumnHeader(text: 'Name'),
+                    value: (row) => row.name,
+                    xsCols: 6,
+                  ),
+                  IntColumn<_Person>(
+                    fieldName: 'age',
+                    header: const ColumnHeader(text: 'Age'),
+                    value: (row) => row.age,
+                    xsCols: 6,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Ada'), findsWidgets);
+      expect(find.text('36'), findsWidgets);
+    },
+  );
 }

--- a/responsive_data_grid/test/layout_constraints_test.dart
+++ b/responsive_data_grid/test/layout_constraints_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+  final int age;
+
+  const _Person(this.name, this.age);
+}
+
+ResponsiveDataGrid<_Person> _grid({
+  double? height,
+  PagingMode pagingMode = PagingMode.pager,
+}) {
+  return ResponsiveDataGrid<_Person>.clientSide(
+    items: const [
+      _Person('Ada', 36),
+      _Person('Grace', 41),
+    ],
+    pageSize: 10,
+    pagingMode: pagingMode,
+    height: height,
+    columns: [
+      StringColumn<_Person>(
+        fieldName: 'name',
+        header: const ColumnHeader(text: 'Name', showOrderBy: true),
+        value: (row) => row.name,
+        xsCols: 6,
+      ),
+      IntColumn<_Person>(
+        fieldName: 'age',
+        header: const ColumnHeader(text: 'Age'),
+        value: (row) => row.age,
+        xsCols: 6,
+      ),
+    ],
+  );
+}
+
+void main() {
+  testWidgets(
+    'grid inside a parent ListView does not throw unbounded Expanded',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: [
+                _grid(height: null, pagingMode: PagingMode.pager),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Name'), findsWidgets);
+      expect(find.text('Ada'), findsWidgets);
+    },
+  );
+
+  testWidgets('bounded-height grid still renders rows', (tester) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: _grid(height: 600, pagingMode: PagingMode.pager),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Ada'), findsWidgets);
+    expect(find.byType(Expanded), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #7. The body always wrapped itself in `Expanded` even when the parent Column was `MainAxisSize.min` with unbounded height (grid inside a `ListView`). That is a classic Flutter layout crash.

## Changes
- `Expanded` only when `constraints.hasBoundedHeight`
- Loading spinner occupies the same flex slot
- Grouped `ListView.builder` shrink-wraps when unbounded
- `groupIndent` is honored
- Missing page map entries no longer force-unwrap

## Test plan
- [x] `dart analyze lib test`
- [x] `flutter test test/layout_constraints_test.dart test/theme_force_unwrap_test.dart`
- [ ] Copilot review

Closes #7