### PR TITLE
fix(grid): clear spinner and show retry when load fails

### DIFF
--- a/responsive_data_grid/lib/responsive_data_grid.dart
+++ b/responsive_data_grid/lib/responsive_data_grid.dart
@@ -90,6 +90,8 @@ class LocalizedMessages {
   static var doesNotInclude = "Does Not Include";
   static var clear = "Clear";
   static var noEntry = "No Entry";
+  static var retry = "Retry";
+  static var loadFailed = "Unable to load data.";
 }
 
 class DecimalTextInputFormatter extends TextInputFormatter {

--- a/responsive_data_grid/lib/src/grid.dart
+++ b/responsive_data_grid/lib/src/grid.dart
@@ -31,6 +31,7 @@ class ResponsiveDataGrid<TItem extends Object> extends StatefulWidget {
   final int groupIndent;
   final bool allowGrouping;
   final bool allowAggregations;
+  final void Function(Object error, StackTrace stackTrace)? onLoadError;
 
   const ResponsiveDataGrid.serverSide({
     GlobalKey<ResponsiveDataGridState<TItem>>? key,
@@ -58,6 +59,7 @@ class ResponsiveDataGrid<TItem extends Object> extends StatefulWidget {
     this.pagingMode = PagingMode.auto,
     this.allowAggregations = false,
     this.maximumRows = 99999,
+    this.onLoadError,
   }) : items = null,
        super(key: key);
 
@@ -91,6 +93,7 @@ class ResponsiveDataGrid<TItem extends Object> extends StatefulWidget {
     this.pagingMode = PagingMode.auto,
     this.allowAggregations = false,
     this.maximumRows = 99999,
+    this.onLoadError,
   }) : loadData = null,
        super(key: key);
 

--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -163,9 +163,8 @@ class ResponsiveDataGridState<TItem extends Object>
 
     try {
       await fetchPage(pageNumber, false);
-    } catch (error, stackTrace) {
+    } catch (error) {
       loadError = error;
-      widget.onLoadError?.call(error, stackTrace);
     } finally {
       if (mounted) {
         setState(() {
@@ -230,6 +229,9 @@ class ResponsiveDataGridState<TItem extends Object>
       }
 
       return response;
+    } catch (error, stackTrace) {
+      widget.onLoadError?.call(error, stackTrace);
+      rethrow;
     } finally {
       if (updateState && mounted) {
         setState(() => isLoading = false);

--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -6,6 +6,7 @@ class ResponsiveDataGridState<TItem extends Object>
   int pageNumber = 1;
 
   var isLoading = false;
+  Object? loadError;
 
   final _dataCache = ResponseCache<TItem>();
 
@@ -67,6 +68,7 @@ class ResponsiveDataGridState<TItem extends Object>
   FutureOr<void> refreshData() async {
     setState(() {
       isLoading = true;
+      loadError = null;
       criteria = criteria.copyWith(
         skip: () => (pageNumber - 1) * widget.pageSize,
         take: () => widget.pageSize,
@@ -92,11 +94,15 @@ class ResponsiveDataGridState<TItem extends Object>
       _dataCache.clear();
     });
 
-    await setPage(1);
-
-    setState(() {
-      isLoading = false;
-    });
+    try {
+      await setPage(1);
+    } finally {
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
+    }
   }
 
   FutureOr<void> addGroup(GroupCriteria group) async {
@@ -126,7 +132,10 @@ class ResponsiveDataGridState<TItem extends Object>
   }
 
   FutureOr<void> setPage(int pageNumber) async {
-    setState(() => isLoading = true);
+    setState(() {
+      isLoading = true;
+      loadError = null;
+    });
 
     this.pageNumber = pageNumber;
 
@@ -152,11 +161,18 @@ class ResponsiveDataGridState<TItem extends Object>
           .toList(),
     );
 
-    await fetchPage(pageNumber, false);
-
-    setState(() {
-      isLoading = false;
-    });
+    try {
+      await fetchPage(pageNumber, false);
+    } catch (error, stackTrace) {
+      loadError = error;
+      widget.onLoadError?.call(error, stackTrace);
+    } finally {
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
+    }
   }
 
   Future<ListResponse<TItem>> fetchPage(
@@ -173,41 +189,52 @@ class ResponsiveDataGridState<TItem extends Object>
       setState(() => isLoading = true);
     }
 
-    if (widget.items != null) {
-      response = ListResponse.fromData(
-        data: widget.items!,
-        criteria: criteria,
-        getFieldValue: (fieldName, item) => widget.columns
-            .firstWhere((c) => c.fieldName == fieldName)
-            .value(item),
-      );
-    } else if (widget.loadData != null) {
-      response =
-          await widget.loadData!(
-            LoadCriteria(
-              skip: (pageNumber - 1) * widget.pageSize,
-              take: widget.pageSize,
-              orderBy: criteria.orderBy,
-              filterBy: criteria.filterBy,
-              groupBy: criteria.groupBy,
-            ),
-          ) ??
-          ListResponse(totalCount: 0, items: [], groups: [], aggregates: []);
-    } else {
-      throw UnsupportedError(
-        "Either the items must be specified OR the loadData function must be specified.",
-      );
-    }
+    try {
+      if (widget.items != null) {
+        response = ListResponse.fromData(
+          data: widget.items!,
+          criteria: criteria,
+          getFieldValue: (fieldName, item) => widget.columns
+              .firstWhere((c) => c.fieldName == fieldName)
+              .value(item),
+        );
+      } else if (widget.loadData != null) {
+        response =
+            await widget.loadData!(
+              LoadCriteria(
+                skip: (pageNumber - 1) * widget.pageSize,
+                take: widget.pageSize,
+                orderBy: criteria.orderBy,
+                filterBy: criteria.filterBy,
+                groupBy: criteria.groupBy,
+              ),
+            ) ??
+            ListResponse(
+              totalCount: 0,
+              items: [],
+              groups: [],
+              aggregates: [],
+            );
+      } else {
+        throw UnsupportedError(
+          "Either the items must be specified OR the loadData function must be specified.",
+        );
+      }
 
-    if (updateState) {
-      setState(() {
+      if (updateState) {
+        setState(() {
+          _dataCache.addPage(response, pageNumber);
+        });
+      } else {
         _dataCache.addPage(response, pageNumber);
-      });
-    } else {
-      _dataCache.addPage(response, pageNumber);
-    }
+      }
 
-    return response;
+      return response;
+    } finally {
+      if (updateState && mounted) {
+        setState(() => isLoading = false);
+      }
+    }
   }
 
   @override
@@ -275,6 +302,28 @@ class ResponsiveDataGridState<TItem extends Object>
                     constraints.hasBoundedHeight
                         ? Expanded(child: spinner)
                         : spinner,
+                  );
+                } else if (loadError != null) {
+                  final errorView = Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(LocalizedMessages.loadFailed),
+                          const SizedBox(height: 8),
+                          TextButton(
+                            onPressed: () => refreshData(),
+                            child: Text(LocalizedMessages.retry),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                  parts.add(
+                    constraints.hasBoundedHeight
+                        ? Expanded(child: errorView)
+                        : errorView,
                   );
                 } else {
                   parts.add(

--- a/responsive_data_grid/test/load_error_test.dart
+++ b/responsive_data_grid/test/load_error_test.dart
@@ -1,0 +1,74 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+
+  const _Person(this.name);
+}
+
+void main() {
+  testWidgets(
+    'server load failure clears the spinner and shows retry',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      Object? reported;
+      var attempts = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.serverSide(
+                height: 600,
+                pagingMode: PagingMode.pager,
+                onLoadError: (error, _) => reported = error,
+                loadData: (criteria) async {
+                  attempts++;
+                  if (attempts == 1) {
+                    throw StateError('backend down');
+                  }
+                  return ListResponse<_Person>(
+                    totalCount: 1,
+                    items: const [_Person('Ada')],
+                    groups: const [],
+                    aggregates: const [],
+                  );
+                },
+                columns: [
+                  StringColumn<_Person>(
+                    fieldName: 'name',
+                    header: const ColumnHeader(text: 'Name'),
+                    value: (row) => row.name,
+                    xsCols: 12,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text(LocalizedMessages.retry), findsOneWidget);
+      expect(reported, isA<StateError>());
+
+      await tester.tap(find.text(LocalizedMessages.retry));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.text(LocalizedMessages.retry), findsNothing);
+      expect(find.text('Ada'), findsWidgets);
+    },
+  );
+}

--- a/responsive_data_grid/test/load_error_test.dart
+++ b/responsive_data_grid/test/load_error_test.dart
@@ -71,4 +71,63 @@ void main() {
       expect(find.text('Ada'), findsWidgets);
     },
   );
+
+  testWidgets(
+    'fetchPage used by infinite scroll still reports onLoadError',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final key = GlobalKey<ResponsiveDataGridState<_Person>>();
+      Object? reported;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.serverSide(
+                key: key,
+                height: 600,
+                pageSize: 1,
+                pagingMode: PagingMode.pager,
+                onLoadError: (error, _) => reported = error,
+                loadData: (criteria) async {
+                  if ((criteria.skip ?? 0) >= 1) {
+                    throw StateError('page 2');
+                  }
+                  return ListResponse<_Person>(
+                    totalCount: 2,
+                    items: const [_Person('Ada')],
+                    groups: const [],
+                    aggregates: const [],
+                  );
+                },
+                columns: [
+                  StringColumn<_Person>(
+                    fieldName: 'name',
+                    header: const ColumnHeader(text: 'Name'),
+                    value: (row) => row.name,
+                    xsCols: 12,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(reported, isNull);
+      await expectLater(
+        key.currentState!.fetchPage(2, false),
+        throwsA(isA<StateError>()),
+      );
+      expect(reported, isA<StateError>());
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Fixes #27. `refreshData` / `setPage` / `fetchPage` had no `try/finally`, so a throwing `loadData` left `isLoading` true forever.

## Changes
- Always clear `isLoading` in `finally`
- In-grid error + Retry
- Optional `onLoadError` on client and server constructors
- Widget test: first load throws, spinner gone, retry succeeds

Closes #27