### PR TITLE
fix(grid): dispose cache subscription and filter controllers

### DIFF
--- a/responsive_data_grid/lib/src/filters/double.dart
+++ b/responsive_data_grid/lib/src/filters/double.dart
@@ -63,6 +63,13 @@ class DataGridDoubleColumnFilterState<TItem extends Object>
   }
 
   @override
+  void dispose() {
+    tecValue1.dispose();
+    tecValue2.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/responsive_data_grid/lib/src/filters/int.dart
+++ b/responsive_data_grid/lib/src/filters/int.dart
@@ -78,6 +78,13 @@ class DataGridIntColumnFilterState<TItem extends Object>
   }
 
   @override
+  void dispose() {
+    tecValue1.dispose();
+    tecValue2.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.max,

--- a/responsive_data_grid/lib/src/filters/num.dart
+++ b/responsive_data_grid/lib/src/filters/num.dart
@@ -62,6 +62,13 @@ class DataGridNumColumnFilterState<TItem extends Object>
   }
 
   @override
+  void dispose() {
+    tecValue1.dispose();
+    tecValue2.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/responsive_data_grid/lib/src/widgets/infinite_scroll_body.dart
+++ b/responsive_data_grid/lib/src/widgets/infinite_scroll_body.dart
@@ -22,17 +22,19 @@ class _ResponsiveGridInfiniteScrollBodyWidgetState<TItem extends Object>
     getNextPageKey: (state) => (state.keys?.last ?? 0) + 1,
     fetchPage: (pageKey) => _fetchPage(pageKey),
   );
+  late final StreamSubscription<void> _onClearedSub;
 
   @override
   void initState() {
     super.initState();
-    widget.gridState._dataCache.onCleared.listen((void v) {
+    _onClearedSub = widget.gridState._dataCache.onCleared.listen((void v) {
       _controller.refresh();
     });
   }
 
   @override
   void dispose() {
+    _onClearedSub.cancel();
     _controller.dispose();
     super.dispose();
   }

--- a/responsive_data_grid/test/resource_dispose_test.dart
+++ b/responsive_data_grid/test/resource_dispose_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final String name;
+
+  const _Person(this.id, this.name);
+}
+
+void main() {
+  testWidgets(
+    'disposing an infinite-scroll grid does not throw after cache clear',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.clientSide(
+                height: 600,
+                pagingMode: PagingMode.infiniteScroll,
+                items: const [
+                  _Person(1, 'Ada'),
+                  _Person(2, 'Grace'),
+                ],
+                columns: [
+                  IntColumn<_Person>(
+                    fieldName: 'id',
+                    header: const ColumnHeader(
+                      text: 'Id',
+                      showFilter: true,
+                    ),
+                    value: (row) => row.id,
+                    xsCols: 4,
+                  ),
+                  StringColumn<_Person>(
+                    fieldName: 'name',
+                    header: const ColumnHeader(text: 'Name'),
+                    value: (row) => row.name,
+                    xsCols: 8,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.text('Ada'), findsWidgets);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('disposing an int filter menu does not throw', (tester) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              items: const [_Person(1, 'Ada')],
+              columns: [
+                IntColumn<_Person>(
+                  fieldName: 'id',
+                  header: const ColumnHeader(text: 'Id', showFilter: true),
+                  value: (row) => row.id,
+                  xsCols: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #28. Infinite-scroll listened to `_dataCache.onCleared` without cancelling. Numeric filters allocated `TextEditingController`s and never disposed them.

## Changes
- Store and cancel the cache-clear subscription
- Dispose `tecValue1`/`tecValue2` in int/double/num filters
- Widget tests dispose infinite-scroll grid and int filter menu

Closes #28