### PR TITLE
fix(grid): require WidgetColumn fieldName and drop fake aggregations

### DIFF
--- a/responsive_data_grid/lib/src/definitions/columns/widget.dart
+++ b/responsive_data_grid/lib/src/definitions/columns/widget.dart
@@ -2,7 +2,7 @@ part of '../../../responsive_data_grid.dart';
 
 class WidgetColumn<TItem extends Object> extends GridColumn<TItem, void> {
   WidgetColumn({
-    String? fieldName,
+    required super.fieldName,
     required Widget Function(TItem item) widget,
     super.aggregations,
     WidgetColumnHeader? header,
@@ -20,7 +20,6 @@ class WidgetColumn<TItem extends Object> extends GridColumn<TItem, void> {
     super.accentColor,
     AlignmentGeometry super.alignment = Alignment.centerLeft,
   }) : super(
-         fieldName: fieldName ?? math.Random().nextDouble().toString(),
          value: (item) {},
          customFieldWidget: widget,
          format: (value) => null,
@@ -33,17 +32,10 @@ class WidgetColumn<TItem extends Object> extends GridColumn<TItem, void> {
   List<AggregationChooser<TItem>> getAggregations({
     required Iterable<AggregateCriteria> selected,
     required void Function(AggregateCriteria aggregate, bool value) update,
-  }) => [
-    AggregationChooser(
-      column: this,
-      aggregation: Aggregations.count,
-      selected: selected,
-      update: update,
-    ),
-  ];
+  }) => const [];
 
   @override
-  bool get hasAggregations => true;
+  bool get hasAggregations => false;
 }
 
 class WidgetColumnHeader extends ColumnHeader {

--- a/responsive_data_grid/test/widget_column_test.dart
+++ b/responsive_data_grid/test/widget_column_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  const _Person();
+}
+
+void main() {
+  test('WidgetColumn keeps a stable fieldName and has no aggregations', () {
+    final col = WidgetColumn<_Person>(
+      fieldName: 'selected',
+      widget: (_) => const SizedBox(),
+    );
+
+    expect(col.fieldName, 'selected');
+    expect(col.hasAggregations, isFalse);
+    expect(
+      col.getAggregations(selected: const [], update: (_, _) {}),
+      isEmpty,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #31. `WidgetColumn` used `Random().nextDouble()` as `fieldName` when omitted, so grouping/aggregates/order keyed by field name were unstable. It also advertised `hasAggregations` on a void field.

## Changes
- `fieldName` is required
- `hasAggregations` is false; no aggregation choosers
- Unit test for stable name and empty aggregations

Closes #31