### PR TITLE
fix(grid): honor unused APIs and correct ColumnHeader copyWith

### DIFF
--- a/responsive_data_grid/lib/src/definitions/column_header.dart
+++ b/responsive_data_grid/lib/src/definitions/column_header.dart
@@ -36,6 +36,7 @@ class ColumnHeader {
         other.textAlign == textAlign &&
         other.showFilter == showFilter &&
         other.showOrderBy == showOrderBy &&
+        other.showAggregations == showAggregations &&
         other.textStyle == textStyle &&
         other.backgroundColor == backgroundColor &&
         other.foregroundColor == foregroundColor;
@@ -49,6 +50,7 @@ class ColumnHeader {
         textAlign.hashCode ^
         showFilter.hashCode ^
         showOrderBy.hashCode ^
+        showAggregations.hashCode ^
         textStyle.hashCode ^
         backgroundColor.hashCode ^
         foregroundColor.hashCode;
@@ -56,7 +58,7 @@ class ColumnHeader {
 
   @override
   String toString() {
-    return 'ColumnHeader(empty: $empty, text: $text, alignment: $alignment, textAlign: $textAlign, showMenu: $showMenu, textStyle: $textStyle, backgroundColor: $backgroundColor, foregroundColor: $foregroundColor)';
+    return 'ColumnHeader(empty: $empty, text: $text, alignment: $alignment, textAlign: $textAlign, showFilter: $showFilter, showOrderBy: $showOrderBy, showAggregations: $showAggregations, textStyle: $textStyle, backgroundColor: $backgroundColor, foregroundColor: $foregroundColor)';
   }
 
   ColumnHeader copyWith({
@@ -66,6 +68,7 @@ class ColumnHeader {
     TextAlign Function()? textAlign,
     bool Function()? showFilter,
     bool Function()? showOrderBy,
+    bool Function()? showAggregations,
     TextStyle? Function()? textStyle,
     Color? Function()? backgroundColor,
     Color? Function()? foregroundColor,
@@ -76,7 +79,10 @@ class ColumnHeader {
       alignment: alignment == null ? this.alignment : alignment(),
       textAlign: textAlign == null ? this.textAlign : textAlign(),
       showFilter: showFilter == null ? this.showFilter : showFilter(),
-      showOrderBy: showOrderBy == null ? this.showFilter : showOrderBy(),
+      showOrderBy: showOrderBy == null ? this.showOrderBy : showOrderBy(),
+      showAggregations: showAggregations == null
+          ? this.showAggregations
+          : showAggregations(),
       textStyle: textStyle == null ? this.textStyle : textStyle(),
       backgroundColor: backgroundColor == null
           ? this.backgroundColor

--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -10,6 +10,13 @@ class ResponsiveDataGridState<TItem extends Object>
 
   final _dataCache = ResponseCache<TItem>();
 
+  int get _takeCount => widget.pagingMode == PagingMode.none
+      ? widget.maximumRows
+      : widget.pageSize;
+
+  int _skipForPage(int page) =>
+      widget.pagingMode == PagingMode.none ? 0 : (page - 1) * widget.pageSize;
+
   ResponsiveDataGridState() {
     //Validate that everything is setup correctly.
     if (TItem == Object) {
@@ -22,7 +29,7 @@ class ResponsiveDataGridState<TItem extends Object>
     super.initState();
     criteria =
         widget.initialLoadCriteria?.copyWith(
-          take: () => widget.initialLoadCriteria!.take ?? widget.pageSize,
+          take: () => widget.initialLoadCriteria!.take ?? _takeCount,
           groupBy: () =>
               widget.initialLoadCriteria!.groupBy ??
               List<GroupCriteria>.empty(growable: true),
@@ -32,7 +39,7 @@ class ResponsiveDataGridState<TItem extends Object>
         ) ??
         LoadCriteria(
           skip: 0,
-          take: widget.pageSize,
+          take: _takeCount,
           aggregates: widget.columns
               .map((e) => e.aggregations)
               .selectMany((element, index) => element)
@@ -70,8 +77,8 @@ class ResponsiveDataGridState<TItem extends Object>
       isLoading = true;
       loadError = null;
       criteria = criteria.copyWith(
-        skip: () => (pageNumber - 1) * widget.pageSize,
-        take: () => widget.pageSize,
+        skip: () => _skipForPage(pageNumber),
+        take: () => _takeCount,
         filterBy: () => widget.columns
             .where((c) => c.filterRules.criteria != null)
             .map((c) => c.filterRules.criteria!)
@@ -140,8 +147,8 @@ class ResponsiveDataGridState<TItem extends Object>
     this.pageNumber = pageNumber;
 
     criteria = criteria.copyWith(
-      skip: () => (pageNumber - 1) * widget.pageSize,
-      take: () => widget.pageSize,
+      skip: () => _skipForPage(pageNumber),
+      take: () => _takeCount,
       filterBy: () => widget.columns
           .where((c) => c.filterRules.criteria != null)
           .map((c) => c.filterRules.criteria!)
@@ -201,8 +208,8 @@ class ResponsiveDataGridState<TItem extends Object>
         response =
             await widget.loadData!(
               LoadCriteria(
-                skip: (pageNumber - 1) * widget.pageSize,
-                take: widget.pageSize,
+                skip: _skipForPage(pageNumber),
+                take: _takeCount,
                 orderBy: criteria.orderBy,
                 filterBy: criteria.filterBy,
                 groupBy: criteria.groupBy,

--- a/responsive_data_grid/lib/src/widgets/column_header.dart
+++ b/responsive_data_grid/lib/src/widgets/column_header.dart
@@ -149,7 +149,8 @@ class ColumnHeaderState<TItem extends Object, TValue extends dynamic>
       );
     }
 
-    if (header.showFilter || header.showAggregations) {
+    if (header.showFilter ||
+        (header.showAggregations && grid.widget.allowAggregations)) {
       items.add(
         ColumnMenu(
           column: widget.definition,

--- a/responsive_data_grid/lib/src/widgets/column_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/column_menu.dart
@@ -37,10 +37,12 @@ class ColumnMenu<T extends Object> extends DropDownViewWidget {
     BuildContext context,
     void Function(BuildContext context) close,
   ) {
-    final aggregates = column.getAggregations(
-      selected: column.aggregations,
-      update: updateAggregations,
-    );
+    final aggregates = gridState.widget.allowAggregations
+        ? column.getAggregations(
+            selected: column.aggregations,
+            update: updateAggregations,
+          )
+        : <AggregationChooser<T>>[];
 
     return Column(
       children: [

--- a/responsive_data_grid/test/column_header_api_test.dart
+++ b/responsive_data_grid/test/column_header_api_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+void main() {
+  test('copyWith showOrderBy does not copy showFilter', () {
+    const header = ColumnHeader(showFilter: true, showOrderBy: false);
+
+    final copied = header.copyWith();
+
+    expect(copied.showFilter, isTrue);
+    expect(copied.showOrderBy, isFalse);
+  });
+
+  test('equality and hashCode include showAggregations', () {
+    const withAgg = ColumnHeader(text: 'Id', showAggregations: true);
+    const withoutAgg = ColumnHeader(text: 'Id', showAggregations: false);
+
+    expect(withAgg == withoutAgg, isFalse);
+    expect(withAgg.hashCode, isNot(withoutAgg.hashCode));
+    expect(withAgg, const ColumnHeader(text: 'Id', showAggregations: true));
+  });
+
+  test('toString includes filter, order, and aggregations flags', () {
+    const header = ColumnHeader(
+      text: 'Name',
+      showFilter: true,
+      showOrderBy: true,
+      showAggregations: true,
+    );
+
+    final text = header.toString();
+    expect(text, contains('showFilter: true'));
+    expect(text, contains('showOrderBy: true'));
+    expect(text, contains('showAggregations: true'));
+    expect(text, isNot(contains('showMenu')));
+  });
+}

--- a/responsive_data_grid/test/grid_api_behavior_test.dart
+++ b/responsive_data_grid/test/grid_api_behavior_test.dart
@@ -1,0 +1,143 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final String name;
+
+  const _Person(this.id, this.name);
+}
+
+List<GridColumn<_Person, dynamic>> _columns({bool showAggregations = false}) {
+  return [
+    IntColumn<_Person>(
+      fieldName: 'id',
+      header: ColumnHeader(
+        text: 'Id',
+        showFilter: true,
+        showAggregations: showAggregations,
+      ),
+      value: (row) => row.id,
+      xsCols: 12,
+    ),
+  ];
+}
+
+void main() {
+  testWidgets('PagingMode.none loads up to maximumRows, not pageSize', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    LoadCriteria? seen;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.serverSide(
+              height: 600,
+              pagingMode: PagingMode.none,
+              pageSize: 10,
+              maximumRows: 123,
+              loadData: (criteria) async {
+                seen = criteria;
+                return ListResponse<_Person>(
+                  totalCount: 1,
+                  items: const [_Person(1, 'Ada')],
+                  groups: const [],
+                  aggregates: const [],
+                );
+              },
+              columns: _columns(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(seen, isNotNull);
+    expect(seen!.take, 123);
+    expect(seen!.skip, 0);
+    expect(find.byType(PagerWidget), findsNothing);
+  });
+
+  testWidgets('aggregations stay hidden when allowAggregations is false', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              allowAggregations: false,
+              items: const [_Person(1, 'Ada')],
+              columns: _columns(showAggregations: true),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Aggregates'), findsNothing);
+  });
+
+  testWidgets('aggregations appear when allowAggregations is true', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              allowAggregations: true,
+              items: const [_Person(1, 'Ada')],
+              columns: _columns(showAggregations: true),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Aggregates'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #8.

## Changes
- `PagingMode.none` uses `maximumRows` as `take` (skip 0)
- Aggregation menu is shown only when `allowAggregations` is true
- `ColumnHeader.copyWith` copies `showOrderBy` (not `showFilter`)
- Equality/hashCode include `showAggregations`; `toString` no longer references `showMenu`
- `groupIndent` already honored (#7)

## Out of scope
- Pixel `width`/`minWidth`/`maxWidth` stay declared for #11 (column freeze/resize)
- CHANGELOG 0.0.12 scroll-physics API is not reintroduced

Closes #8