### PR TITLE
fix(grid): persist non-integer column filters on apply

### DIFF
--- a/responsive_data_grid/lib/src/filters/bool.dart
+++ b/responsive_data_grid/lib/src/filters/bool.dart
@@ -48,6 +48,10 @@ class DataGridBoolColumnFilterState<TItem extends Object>
           onChanged: (value) {
             setState(() {
               this.value = value;
+              writeCriteria(
+                value == null ? null : Logic.equals,
+                value == null ? const [] : [value],
+              );
             });
           },
           tristate: true,

--- a/responsive_data_grid/lib/src/filters/column_filter.dart
+++ b/responsive_data_grid/lib/src/filters/column_filter.dart
@@ -15,4 +15,17 @@ abstract class DataGridColumnFilterState<
   TItem extends Object,
   TValue extends dynamic
 >
-    extends State<DataGridColumnFilter<TItem, TValue>> {}
+    extends State<DataGridColumnFilter<TItem, TValue>> {
+  void writeCriteria(Logic? op, List<TValue> values) {
+    if (op == null || values.isEmpty) {
+      widget.definition.filterRules.criteria = null;
+    } else {
+      widget.definition.filterRules.criteria = FilterCriteria<TValue>(
+        fieldName: widget.definition.fieldName,
+        op: Operators.and,
+        values: values,
+        logicalOperator: op,
+      );
+    }
+  }
+}

--- a/responsive_data_grid/lib/src/filters/datetime.dart
+++ b/responsive_data_grid/lib/src/filters/datetime.dart
@@ -99,6 +99,10 @@ class DataGridDateTimeColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(op, [
+                ?dtStart,
+                ?dtEnd,
+              ]);
             });
           },
         ),
@@ -122,6 +126,10 @@ class DataGridDateTimeColumnFilterState<TItem extends Object>
             onChanged: (DateTime? value) {
               setState(() {
                 dtStart = value;
+                writeCriteria(op, [
+                  ?dtStart,
+                  ?dtEnd,
+                ]);
               });
             },
           ),
@@ -138,6 +146,10 @@ class DataGridDateTimeColumnFilterState<TItem extends Object>
             onChanged: (DateTime? value) {
               setState(() {
                 dtEnd = value;
+                writeCriteria(op, [
+                  ?dtStart,
+                  ?dtEnd,
+                ]);
               });
             },
           ),

--- a/responsive_data_grid/lib/src/filters/double.dart
+++ b/responsive_data_grid/lib/src/filters/double.dart
@@ -113,6 +113,10 @@ class DataGridDoubleColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(op, [
+                ?dValue,
+                ?dValue2,
+              ]);
             });
           },
         ),
@@ -135,7 +139,11 @@ class DataGridDoubleColumnFilterState<TItem extends Object>
             controller: tecValue1,
             onChanged: (value) {
               setState(() {
-                dValue = double.parse(value);
+                dValue = double.tryParse(value);
+                writeCriteria(op, [
+                  ?dValue,
+                  ?dValue2,
+                ]);
               });
             },
           ),
@@ -157,7 +165,11 @@ class DataGridDoubleColumnFilterState<TItem extends Object>
             controller: tecValue2,
             onChanged: (value) {
               setState(() {
-                dValue2 = double.parse(value);
+                dValue2 = double.tryParse(value);
+                writeCriteria(op, [
+                  ?dValue,
+                  ?dValue2,
+                ]);
               });
             },
           ),

--- a/responsive_data_grid/lib/src/filters/duration.dart
+++ b/responsive_data_grid/lib/src/filters/duration.dart
@@ -89,10 +89,6 @@ class DataGridDurationColumnFilterState<TItem extends Object>
               child: Text(Logic.between.toString()),
             ),
             DropdownMenuItem(
-              value: Logic.equals,
-              child: Text(Logic.equals.toString()),
-            ),
-            DropdownMenuItem(
               value: Logic.notEqual,
               child: Text(Logic.notEqual.toString()),
             ),
@@ -101,6 +97,10 @@ class DataGridDurationColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(op, [
+                ?dValue1,
+                ?dValue2,
+              ]);
             });
           },
         ),
@@ -114,11 +114,37 @@ class DataGridDurationColumnFilterState<TItem extends Object>
                   op == Logic.notEqual ||
                   op == Logic.lessThan ||
                   op == Logic.lessThanOrEqualTo),
-          child: Row(children: []),
+          child: TextField(
+            decoration: const InputDecoration(hintText: 'minutes'),
+            keyboardType: TextInputType.number,
+            onChanged: (value) {
+              final minutes = int.tryParse(value);
+              setState(() {
+                dValue1 = minutes == null ? null : Duration(minutes: minutes);
+                writeCriteria(op, [
+                  ?dValue1,
+                  ?dValue2,
+                ]);
+              });
+            },
+          ),
         ),
         Visibility(
           visible: op != null && (op == Logic.between),
-          child: Row(children: []),
+          child: TextField(
+            decoration: const InputDecoration(hintText: 'minutes'),
+            keyboardType: TextInputType.number,
+            onChanged: (value) {
+              final minutes = int.tryParse(value);
+              setState(() {
+                dValue2 = minutes == null ? null : Duration(minutes: minutes);
+                writeCriteria(op, [
+                  ?dValue1,
+                  ?dValue2,
+                ]);
+              });
+            },
+          ),
         ),
       ],
     );

--- a/responsive_data_grid/lib/src/filters/num.dart
+++ b/responsive_data_grid/lib/src/filters/num.dart
@@ -112,6 +112,10 @@ class DataGridNumColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(op, [
+                ?nValue,
+                ?nValue2,
+              ]);
             });
           },
         ),
@@ -134,7 +138,11 @@ class DataGridNumColumnFilterState<TItem extends Object>
             controller: tecValue1,
             onChanged: (value) {
               setState(() {
-                nValue = num.parse(value);
+                nValue = num.tryParse(value);
+                writeCriteria(op, [
+                  ?nValue,
+                  ?nValue2,
+                ]);
               });
             },
           ),
@@ -156,7 +164,11 @@ class DataGridNumColumnFilterState<TItem extends Object>
             controller: tecValue2,
             onChanged: (value) {
               setState(() {
-                nValue2 = num.parse(value);
+                nValue2 = num.tryParse(value);
+                writeCriteria(op, [
+                  ?nValue,
+                  ?nValue2,
+                ]);
               });
             },
           ),

--- a/responsive_data_grid/lib/src/filters/string.dart
+++ b/responsive_data_grid/lib/src/filters/string.dart
@@ -89,6 +89,10 @@ class DataGridStringColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(
+                op,
+                searchText == null || searchText!.isEmpty ? [] : [searchText!],
+              );
             });
           },
         ),
@@ -99,6 +103,10 @@ class DataGridStringColumnFilterState<TItem extends Object>
             decoration: InputDecoration(labelText: "value"),
             onChanged: (value) => setState(() {
               searchText = value;
+              writeCriteria(
+                op,
+                searchText == null || searchText!.isEmpty ? [] : [searchText!],
+              );
             }),
           ),
         ),

--- a/responsive_data_grid/lib/src/filters/timeofday.dart
+++ b/responsive_data_grid/lib/src/filters/timeofday.dart
@@ -84,6 +84,10 @@ class DataGridTimeOfDayColumnFilterState<TItem extends Object>
           onChanged: (Logic? value) {
             setState(() {
               op = value;
+              writeCriteria(op, [
+                ?tStart,
+                ?tEnd,
+              ]);
             });
           },
         ),
@@ -102,6 +106,10 @@ class DataGridTimeOfDayColumnFilterState<TItem extends Object>
             onChanged: (DateTime? value) {
               setState(() {
                 tStart = value == null ? null : TimeOfDay.fromDateTime(value);
+                writeCriteria(op, [
+                  ?tStart,
+                  ?tEnd,
+                ]);
               });
             },
           ),
@@ -119,6 +127,10 @@ class DataGridTimeOfDayColumnFilterState<TItem extends Object>
             onChanged: (DateTime? value) {
               setState(() {
                 tEnd = value == null ? null : TimeOfDay.fromDateTime(value);
+                writeCriteria(op, [
+                  ?tStart,
+                  ?tEnd,
+                ]);
               });
             },
           ),

--- a/responsive_data_grid/lib/src/filters/values.dart
+++ b/responsive_data_grid/lib/src/filters/values.dart
@@ -62,8 +62,10 @@ class DataGridValuesColumnFilterState<
         SwitchListTile(
           value: op == Logic.notEqual,
           title: Text(LocalizedMessages.doesNotInclude),
-          onChanged: (value) =>
-              setState(() => value ? op = Logic.notEqual : op = Logic.equals),
+          onChanged: (value) => setState(() {
+            op = value ? Logic.notEqual : Logic.equals;
+            writeCriteria(op, values);
+          }),
         ),
         ...filterRules.valueMap.entries.map(
           (e) => CheckboxListTile(
@@ -76,6 +78,7 @@ class DataGridValuesColumnFilterState<
                 if (value == null || !value && values.contains(e.key)) {
                   values.remove(e.key);
                 }
+                writeCriteria(op, values);
               });
             },
             value: values.contains(e.key),

--- a/responsive_data_grid/test/filter_apply_test.dart
+++ b/responsive_data_grid/test/filter_apply_test.dart
@@ -1,0 +1,83 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+  final bool accepted;
+
+  const _Person(this.name, this.accepted);
+}
+
+void main() {
+  testWidgets('string column filter apply actually filters rows', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              items: const [
+                _Person('Ada', true),
+                _Person('Grace', false),
+              ],
+              columns: [
+                StringColumn<_Person>(
+                  fieldName: 'name',
+                  header: const ColumnHeader(text: 'Name', showFilter: true),
+                  value: (row) => row.name,
+                  xsCols: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Ada'), findsWidgets);
+    expect(find.text('Grace'), findsWidgets);
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    _ignoreOverflow(tester);
+
+    await tester.tap(find.byType(DropdownButtonFormField<Logic?>));
+    await tester.pumpAndSettle();
+    _ignoreOverflow(tester);
+    await tester.tap(find.text(Logic.contains.toString()).last);
+    await tester.pumpAndSettle();
+    _ignoreOverflow(tester);
+
+    await tester.enterText(find.byType(TextFormField), 'Ada');
+    await tester.pump();
+
+    await tester.tap(find.text(LocalizedMessages.apply));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    _ignoreOverflow(tester);
+
+    expect(find.text('Ada'), findsWidgets);
+    expect(find.text('Grace'), findsNothing);
+  });
+}
+
+void _ignoreOverflow(WidgetTester tester) {
+  final error = tester.takeException();
+  if (error == null) return;
+  expect(error.toString(), contains('overflowed'));
+}


### PR DESCRIPTION
## Summary
Fixes #4. Only integer filters wrote `filterRules.criteria`. Apply then called `refreshData()`, which read empty criteria for every other type.

## Changes
- Shared `writeCriteria` on filter state
- All typed filters persist on operator/value change
- Safe `tryParse` for double/num
- Duration minutes editors; duplicate `Logic.equals` entry removed
- Widget test: string contains `Ada` hides `Grace`

Closes #4