### PR TITLE
fix(grid): reload on sort, filter, and parent updates

### DIFF
--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -27,8 +27,53 @@ class ResponsiveDataGridState<TItem extends Object>
   @override
   initState() {
     super.initState();
-    criteria =
-        widget.initialLoadCriteria?.copyWith(
+    criteria = _criteriaFromInitial();
+
+    refreshData();
+  }
+
+  @override
+  void dispose() {
+    _dataCache.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant ResponsiveDataGrid<TItem> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (_parentRequiresReload(oldWidget)) {
+      if (oldWidget.initialLoadCriteria != widget.initialLoadCriteria) {
+        criteria = _criteriaFromInitial();
+      }
+      refreshData();
+    }
+  }
+
+  bool _parentRequiresReload(ResponsiveDataGrid<TItem> oldWidget) {
+    return !identical(oldWidget.items, widget.items) ||
+        oldWidget.loadData != widget.loadData ||
+        oldWidget.initialLoadCriteria != widget.initialLoadCriteria ||
+        oldWidget.pageSize != widget.pageSize ||
+        oldWidget.pagingMode != widget.pagingMode ||
+        oldWidget.maximumRows != widget.maximumRows ||
+        _columnsChanged(oldWidget.columns, widget.columns);
+  }
+
+  bool _columnsChanged(
+    List<GridColumn<TItem, dynamic>> oldColumns,
+    List<GridColumn<TItem, dynamic>> newColumns,
+  ) {
+    if (identical(oldColumns, newColumns)) return false;
+    if (oldColumns.length != newColumns.length) return true;
+    for (var i = 0; i < newColumns.length; i++) {
+      if (oldColumns[i].fieldName != newColumns[i].fieldName) return true;
+    }
+    return false;
+  }
+
+  LoadCriteria _criteriaFromInitial() {
+    return widget.initialLoadCriteria?.copyWith(
           take: () => widget.initialLoadCriteria!.take ?? _takeCount,
           groupBy: () =>
               widget.initialLoadCriteria!.groupBy ??
@@ -45,31 +90,20 @@ class ResponsiveDataGridState<TItem extends Object>
               .selectMany((element, index) => element)
               .toList(),
         );
-
-    refreshData();
-  }
-
-  @override
-  void dispose() {
-    _dataCache.dispose();
-    super.dispose();
   }
 
   Future<void> updateFilterCriteria(
     List<FilterCriteria<dynamic>> filterCriteria,
   ) async {
-    setState(() {
-      isLoading = true;
-      criteria = criteria.copyWith(filterBy: () => filterCriteria);
+    for (final filter in filterCriteria) {
+      for (final column in widget.columns) {
+        if (column.fieldName == filter.fieldName) {
+          column.filterRules.criteria = filter;
+        }
+      }
+    }
 
-      _dataCache.clear();
-    });
-
-    setState(() {
-      isLoading = false;
-
-      _rebuildAllChildren();
-    });
+    await refreshData();
   }
 
   FutureOr<void> refreshData() async {
@@ -362,7 +396,10 @@ class ResponsiveDataGridState<TItem extends Object>
                 }
 
                 return NotificationListener<GridCriteriaChangeNotification>(
-                  onNotification: (notification) => false,
+                  onNotification: (notification) {
+                    refreshData();
+                    return true;
+                  },
                   child: Column(
                     mainAxisSize: !constraints.hasBoundedHeight
                         ? MainAxisSize.min
@@ -388,20 +425,8 @@ class ResponsiveDataGridState<TItem extends Object>
   }
 
   void _updateAllRules() {
-    criteria = LoadCriteria();
-    for (var c in widget.columns) {
-      if (c.sortDirection != OrderDirections.notSet) {
-        criteria.orderBy.add(
-          OrderCriteria(fieldName: c.fieldName, direction: c.sortDirection),
-        );
-      }
-
-      if (c.filterRules.criteria != null) {
-        criteria.filterBy.add(c.filterRules.criteria!);
-      }
-    }
-
-    _rebuildAllChildren();
+    refreshData();
+    GridCriteriaChangeNotification().dispatch(context);
   }
 
   void _updateOrderByCriteria<TValue extends dynamic>(

--- a/responsive_data_grid/test/reload_criteria_test.dart
+++ b/responsive_data_grid/test/reload_criteria_test.dart
@@ -1,0 +1,249 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+
+  const _Person(this.name);
+}
+
+List<GridColumn<_Person, dynamic>> _nameColumns({
+  bool showOrderBy = false,
+}) {
+  return [
+    StringColumn<_Person>(
+      fieldName: 'name',
+      header: ColumnHeader(text: 'Name', showOrderBy: showOrderBy),
+      value: (row) => row.name,
+      xsCols: 12,
+    ),
+  ];
+}
+
+ListResponse<_Person> _response(List<_Person> items) {
+  return ListResponse<_Person>(
+    totalCount: items.length,
+    items: items,
+    groups: const [],
+    aggregates: const [],
+  );
+}
+
+void main() {
+  testWidgets(
+    'toggling sort reloads with orderBy and keeps paging and groupBy',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final calls = <LoadCriteria>[];
+      const group = GroupCriteria(fieldName: 'name', aggregates: []);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.serverSide(
+                height: 600,
+                pagingMode: PagingMode.pager,
+                pageSize: 25,
+                initialLoadCriteria: LoadCriteria(
+                  skip: 0,
+                  take: 25,
+                  groupBy: [group],
+                ),
+                loadData: (criteria) async {
+                  calls.add(criteria);
+                  return _response(const [_Person('Ada'), _Person('Grace')]);
+                },
+                columns: _nameColumns(showOrderBy: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(calls, hasLength(1));
+      expect(calls.first.take, 25);
+      expect(calls.first.skip, 0);
+      expect(calls.first.groupBy, isNotNull);
+      expect(calls.first.groupBy, isNotEmpty);
+      expect(calls.first.orderBy, isEmpty);
+
+      await tester.tap(find.byIcon(Icons.sort));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(calls, hasLength(2));
+      final afterSort = calls.last;
+      expect(afterSort.take, 25);
+      expect(afterSort.skip, 0);
+      expect(afterSort.groupBy, isNotNull);
+      expect(afterSort.groupBy, isNotEmpty);
+      expect(afterSort.orderBy, isNotEmpty);
+      expect(afterSort.orderBy.first.fieldName, 'name');
+      expect(afterSort.orderBy.first.direction, OrderDirections.ascending);
+    },
+  );
+
+  testWidgets('updateFilterCriteria reloads with the new filters', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final key = GlobalKey<ResponsiveDataGridState<_Person>>();
+    final calls = <LoadCriteria>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.serverSide(
+              key: key,
+              height: 600,
+              pagingMode: PagingMode.pager,
+              pageSize: 25,
+              loadData: (criteria) async {
+                calls.add(criteria);
+                return _response(const [_Person('Ada')]);
+              },
+              columns: _nameColumns(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(calls, hasLength(1));
+    expect(calls.first.filterBy, isEmpty);
+
+    await key.currentState!.updateFilterCriteria([
+      const FilterCriteria<String>(
+        fieldName: 'name',
+        op: Operators.and,
+        logicalOperator: Logic.equals,
+        values: ['Ada'],
+      ),
+    ]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(calls, hasLength(2));
+    expect(calls.last.filterBy, isNotEmpty);
+    expect(calls.last.filterBy.first.fieldName, 'name');
+    expect(calls.last.filterBy.first.values, ['Ada']);
+    expect(calls.last.take, 25);
+  });
+
+  testWidgets('parent item changes reload the visible rows', (tester) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    var items = const [_Person('Ada')];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return Column(
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        items = const [_Person('Grace')];
+                      });
+                    },
+                    child: const Text('swap'),
+                  ),
+                  Expanded(
+                    child: ResponsiveDataGrid<_Person>.clientSide(
+                      height: 500,
+                      pagingMode: PagingMode.pager,
+                      items: items,
+                      columns: _nameColumns(),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Ada'), findsWidgets);
+    expect(find.text('Grace'), findsNothing);
+
+    await tester.tap(find.text('swap'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Grace'), findsWidgets);
+    expect(find.text('Ada'), findsNothing);
+  });
+
+  testWidgets(
+    'GridCriteriaChangeNotification from a descendant reloads data',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 700);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final calls = <LoadCriteria>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 600,
+              child: ResponsiveDataGrid<_Person>.serverSide(
+                height: 600,
+                pagingMode: PagingMode.pager,
+                loadData: (criteria) async {
+                  calls.add(criteria);
+                  return _response(const [_Person('Ada')]);
+                },
+                columns: _nameColumns(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(calls, hasLength(1));
+
+      final descendant = tester.element(
+        find.byType(ResponsiveDataGridHeaderRowWidget<_Person>),
+      );
+      GridCriteriaChangeNotification().dispatch(descendant);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(calls, hasLength(2));
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #5. Sort, filter, and parent updates rebuilt the widget tree without fetching data, or replaced `LoadCriteria` and dropped take/skip/groupBy.

## Changes
- `_updateAllRules` refreshes instead of replacing criteria and rebuilding only
- `updateFilterCriteria` writes column filters and fetches
- `didUpdateWidget` reloads when items, load callback, paging, columns, or initial criteria change
- `GridCriteriaChangeNotification` is dispatched and consumed with a fetch

## Tests
- Sort keeps take/skip/groupBy and sends orderBy
- Filter API triggers a second load with filterBy
- Parent item swap updates visible rows
- Descendant notification reloads

Closes #5