### PR TITLE
fix(grid): pass aggregates on server-side load

### DIFF
--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -241,12 +241,9 @@ class ResponsiveDataGridState<TItem extends Object>
       } else if (widget.loadData != null) {
         response =
             await widget.loadData!(
-              LoadCriteria(
-                skip: _skipForPage(pageNumber),
-                take: _takeCount,
-                orderBy: criteria.orderBy,
-                filterBy: criteria.filterBy,
-                groupBy: criteria.groupBy,
+              criteria.copyWith(
+                skip: () => _skipForPage(pageNumber),
+                take: () => _takeCount,
               ),
             ) ??
             ListResponse(

--- a/responsive_data_grid/test/server_aggregates_test.dart
+++ b/responsive_data_grid/test/server_aggregates_test.dart
@@ -1,0 +1,83 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final String name;
+
+  const _Person(this.id, this.name);
+}
+
+void main() {
+  testWidgets('server loadData receives column aggregates in LoadCriteria', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    LoadCriteria? seen;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.serverSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              pageSize: 25,
+              allowAggregations: true,
+              loadData: (criteria) async {
+                seen = criteria;
+                return ListResponse<_Person>(
+                  totalCount: 1,
+                  items: const [_Person(1, 'Ada')],
+                  groups: const [],
+                  aggregates: const [],
+                );
+              },
+              columns: [
+                IntColumn<_Person>(
+                  fieldName: 'id',
+                  header: const ColumnHeader(
+                    text: 'Id',
+                    showAggregations: true,
+                  ),
+                  value: (row) => row.id,
+                  xsCols: 6,
+                  aggregations: const [
+                    AggregateCriteria(
+                      fieldName: 'id',
+                      aggregation: Aggregations.sum,
+                    ),
+                  ],
+                ),
+                StringColumn<_Person>(
+                  fieldName: 'name',
+                  header: const ColumnHeader(text: 'Name'),
+                  value: (row) => row.name,
+                  xsCols: 6,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(seen, isNotNull);
+    expect(seen!.aggregates, isNotNull);
+    expect(seen!.aggregates, isNotEmpty);
+    expect(seen!.aggregates!.first.fieldName, 'id');
+    expect(seen!.aggregates!.first.aggregation, Aggregations.sum);
+    expect(seen!.take, 25);
+    expect(seen!.skip, 0);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #6. Server-side `loadData` received a freshly built `LoadCriteria` with skip/take/orderBy/filterBy/groupBy but not aggregates.

## Changes
- `fetchPage` now sends `criteria.copyWith` for the page skip/take so aggregates (and the rest of the criteria) go to the server

## Tests
- Server load with a sum aggregation on `id` receives that aggregate in `LoadCriteria`

Closes #6