### PR TITLE
fix(client_filtering): include groupBy and aggregates in JSON

### DIFF
--- a/client_filtering/lib/src/group_criteria.dart
+++ b/client_filtering/lib/src/group_criteria.dart
@@ -13,7 +13,9 @@ class GroupCriteria with IJsonable {
 
   factory GroupCriteria.fromJson(Map<String, dynamic> json) => GroupCriteria(
     fieldName: json['fieldName'].toString(),
-    direction: OrderDirections.fromInt(json['directions'] as int),
+    direction: OrderDirections.fromInt(
+      (json['direction'] ?? json['directions']) as int,
+    ),
     aggregates: (json["aggregates"] as List)
         .map<AggregateCriteria>(
           (dynamic model) =>
@@ -29,12 +31,12 @@ class GroupCriteria with IJsonable {
     return other is GroupCriteria &&
         other.fieldName == fieldName &&
         other.direction == direction &&
-        other.aggregates == aggregates;
+        listEquals(other.aggregates, aggregates);
   }
 
   @override
   int get hashCode {
-    return fieldName.hashCode ^ direction.hashCode ^ aggregates.hashCode;
+    return Object.hash(fieldName, direction, Object.hashAll(aggregates));
   }
 
   GroupCriteria copyWith({

--- a/client_filtering/lib/src/load_criteria.dart
+++ b/client_filtering/lib/src/load_criteria.dart
@@ -34,6 +34,22 @@ class LoadCriteria with IJsonable {
               OrderCriteria.fromJson(model as Map<String, dynamic>),
         )
         .toList(),
+    groupBy: json["groupBy"] == null
+        ? null
+        : (json["groupBy"] as List)
+              .map<GroupCriteria>(
+                (dynamic model) =>
+                    GroupCriteria.fromJson(model as Map<String, dynamic>),
+              )
+              .toList(),
+    aggregates: json["aggregates"] == null
+        ? null
+        : (json["aggregates"] as List)
+              .map<AggregateCriteria>(
+                (dynamic model) =>
+                    AggregateCriteria.fromJson(model as Map<String, dynamic>),
+              )
+              .toList(),
   );
 
   @override
@@ -44,12 +60,21 @@ class LoadCriteria with IJsonable {
         other.skip == skip &&
         other.take == take &&
         listEquals(other.filterBy, filterBy) &&
-        listEquals(other.orderBy, orderBy);
+        listEquals(other.orderBy, orderBy) &&
+        listEquals(other.groupBy ?? const [], groupBy ?? const []) &&
+        listEquals(other.aggregates ?? const [], aggregates ?? const []);
   }
 
   @override
   int get hashCode {
-    return skip.hashCode ^ take.hashCode ^ filterBy.hashCode ^ orderBy.hashCode;
+    return Object.hash(
+      skip,
+      take,
+      Object.hashAll(filterBy),
+      Object.hashAll(orderBy),
+      Object.hashAll(groupBy ?? const []),
+      Object.hashAll(aggregates ?? const []),
+    );
   }
 
   LoadCriteria copyWith({
@@ -78,6 +103,8 @@ class LoadCriteria with IJsonable {
           'take': take,
           'filterBy': filterBy.map((x) => x.toJson()).toList(),
           'orderBy': orderBy.map((x) => x.toJson()).toList(),
+          'groupBy': groupBy?.map((x) => x.toJson()).toList(),
+          'aggregates': aggregates?.map((x) => x.toJson()).toList(),
         }
         as Map<String, dynamic>;
   }

--- a/client_filtering/test/load_criteria_json_test.dart
+++ b/client_filtering/test/load_criteria_json_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('LoadCriteria JSON round-trips groupBy and aggregates', () {
+    final original = LoadCriteria(
+      skip: 10,
+      take: 25,
+      orderBy: const [
+        OrderCriteria(fieldName: 'name', direction: OrderDirections.ascending),
+      ],
+      groupBy: [
+        const GroupCriteria(
+          fieldName: 'name',
+          direction: OrderDirections.descending,
+          aggregates: [
+            AggregateCriteria(fieldName: 'id', aggregation: Aggregations.sum),
+          ],
+        ),
+      ],
+      aggregates: const [
+        AggregateCriteria(fieldName: 'id', aggregation: Aggregations.count),
+      ],
+    );
+
+    final restored = LoadCriteria.fromJson(
+      jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+    );
+
+    expect(restored.skip, 10);
+    expect(restored.take, 25);
+    expect(restored.orderBy.single.fieldName, 'name');
+    expect(restored.groupBy, isNotNull);
+    expect(restored.groupBy!.single.fieldName, 'name');
+    expect(restored.groupBy!.single.direction, OrderDirections.descending);
+    expect(
+      restored.groupBy!.single.aggregates.single.aggregation,
+      Aggregations.sum,
+    );
+    expect(restored.aggregates, isNotNull);
+    expect(restored.aggregates!.single.fieldName, 'id');
+    expect(restored.aggregates!.single.aggregation, Aggregations.count);
+  });
+
+  test('LoadCriteria equality includes groupBy and aggregates', () {
+    const group = GroupCriteria(
+      fieldName: 'name',
+      aggregates: [
+        AggregateCriteria(fieldName: 'id', aggregation: Aggregations.sum),
+      ],
+    );
+    const aggregate = AggregateCriteria(
+      fieldName: 'id',
+      aggregation: Aggregations.count,
+    );
+
+    final left = LoadCriteria(
+      skip: 0,
+      take: 10,
+      groupBy: [group],
+      aggregates: [aggregate],
+    );
+    final same = LoadCriteria(
+      skip: 0,
+      take: 10,
+      groupBy: [
+        const GroupCriteria(
+          fieldName: 'name',
+          aggregates: [
+            AggregateCriteria(fieldName: 'id', aggregation: Aggregations.sum),
+          ],
+        ),
+      ],
+      aggregates: const [
+        AggregateCriteria(fieldName: 'id', aggregation: Aggregations.count),
+      ],
+    );
+    final differentGroup = LoadCriteria(
+      skip: 0,
+      take: 10,
+      groupBy: [
+        const GroupCriteria(fieldName: 'other', aggregates: []),
+      ],
+      aggregates: [aggregate],
+    );
+    final differentAggregates = LoadCriteria(
+      skip: 0,
+      take: 10,
+      groupBy: [group],
+      aggregates: const [
+        AggregateCriteria(fieldName: 'id', aggregation: Aggregations.sum),
+      ],
+    );
+
+    expect(left, same);
+    expect(left, isNot(equals(differentGroup)));
+    expect(left, isNot(equals(differentAggregates)));
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #29. `LoadCriteria` JSON and equality omitted `groupBy` and `aggregates`, so server round-trips dropped grouping and aggregations.

## Changes
- `toJson` / `fromJson` include `groupBy` and `aggregates`
- Equality and hashCode include those fields
- `GroupCriteria.fromJson` reads `direction` (with fallback to the old `directions` key)
- `GroupCriteria` equality uses list equality for nested aggregates

## Tests
- JSON round-trip of skip/take/orderBy/groupBy/aggregates
- Equality distinguishes different groupBy and aggregates

Closes #29