### PR TITLE
fix(grid): drop date/time sum and theme aggregate footers

### DIFF
--- a/client_filtering/lib/src/aggregate_result.dart
+++ b/client_filtering/lib/src/aggregate_result.dart
@@ -37,7 +37,7 @@ class AggregateResult {
     return fieldName.hashCode ^ aggregation.hashCode ^ result.hashCode;
   }
 
-  String? formatResult(String? format) {
+  String? formatResult([String? format]) {
     if (result == null) return "";
 
     switch (aggregation) {

--- a/responsive_data_grid/lib/src/definitions/columns/datetime.dart
+++ b/responsive_data_grid/lib/src/definitions/columns/datetime.dart
@@ -58,12 +58,6 @@ class DateTimeColumn<TItem extends Object> extends GridColumn<TItem, DateTime> {
       selected: selected,
       update: update,
     ),
-    AggregationChooser(
-      column: this,
-      aggregation: Aggregations.sum,
-      selected: selected,
-      update: update,
-    ),
   ];
 
   @override

--- a/responsive_data_grid/lib/src/definitions/columns/timeofday.dart
+++ b/responsive_data_grid/lib/src/definitions/columns/timeofday.dart
@@ -57,12 +57,6 @@ class TimeOfDayColumn<TItem extends Object>
       selected: selected,
       update: update,
     ),
-    AggregationChooser(
-      column: this,
-      aggregation: Aggregations.sum,
-      selected: selected,
-      update: update,
-    ),
   ];
 
   @override

--- a/responsive_data_grid/lib/src/widgets/grid_footer.dart
+++ b/responsive_data_grid/lib/src/widgets/grid_footer.dart
@@ -14,7 +14,9 @@ class GridFooter<TItem extends Object> extends StatelessWidget {
     return Padding(
       padding: EdgeInsets.only(top: 3),
       child: DecoratedBox(
-        decoration: BoxDecoration(color: Colors.black45),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+        ),
         child: Padding(
           padding: EdgeInsets.only(top: 3, bottom: 3),
           child: BootstrapRow(
@@ -53,8 +55,10 @@ class GridFooter<TItem extends Object> extends StatelessWidget {
                 .where((g) => g.fieldName == c.fieldName && g.result != null)
                 .map(
                   (agg) => Text(
-                    "${agg.aggregation.toString()}: ${agg.formatResult(null)}",
-                    style: theme.textTheme.labelLarge,
+                    "${agg.aggregation}: ${agg.formatResult()}",
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: theme.colorScheme.onSurface,
+                    ),
                   ),
                 )
                 .toList(),

--- a/responsive_data_grid/lib/src/widgets/group_footer.dart
+++ b/responsive_data_grid/lib/src/widgets/group_footer.dart
@@ -19,7 +19,9 @@ class GridGroupFooter<TItem extends Object> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
-      decoration: BoxDecoration(color: Colors.black26),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHigh,
+      ),
       child: Padding(
         padding: EdgeInsets.only(left: 3, top: 3, bottom: 3, right: 3),
         child: BootstrapRow(
@@ -50,8 +52,10 @@ class GridGroupFooter<TItem extends Object> extends StatelessWidget {
               .where((g) => g.fieldName == c.fieldName && g.result != null)
               .map(
                 (agg) => Text(
-                  "${agg.aggregation.toString()}: ${agg.formatResult(null)}",
-                  style: theme.textTheme.labelMedium,
+                  "${agg.aggregation}: ${agg.formatResult()}",
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                  ),
                 ),
               )
               .toList(),

--- a/responsive_data_grid/test/aggregate_footer_test.dart
+++ b/responsive_data_grid/test/aggregate_footer_test.dart
@@ -1,0 +1,98 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final DateTime when;
+  final TimeOfDay time;
+
+  const _Person(this.id, this.when, this.time);
+}
+
+void main() {
+  test('DateTimeColumn does not offer sum', () {
+    final column = DateTimeColumn<_Person>(
+      fieldName: 'when',
+      value: (row) => row.when,
+    );
+
+    final offered = column
+        .getAggregations(selected: const [], update: (_, _) {})
+        .map((chooser) => chooser.aggregation)
+        .toList();
+
+    expect(offered, isNot(contains(Aggregations.sum)));
+    expect(offered, containsAll([
+      Aggregations.minimum,
+      Aggregations.maximum,
+    ]));
+  });
+
+  test('TimeOfDayColumn does not offer sum', () {
+    final column = TimeOfDayColumn<_Person>(
+      fieldName: 'time',
+      value: (row) => row.time,
+    );
+
+    final offered = column
+        .getAggregations(selected: const [], update: (_, _) {})
+        .map((chooser) => chooser.aggregation)
+        .toList();
+
+    expect(offered, isNot(contains(Aggregations.sum)));
+  });
+
+  testWidgets('grid footer shows the formatted aggregate result', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 600,
+              pagingMode: PagingMode.pager,
+              allowAggregations: true,
+              items: [
+                _Person(1, DateTime(2024, 1, 1), const TimeOfDay(hour: 8, minute: 0)),
+                _Person(2, DateTime(2024, 1, 2), const TimeOfDay(hour: 9, minute: 0)),
+                _Person(3, DateTime(2024, 1, 3), const TimeOfDay(hour: 10, minute: 0)),
+              ],
+              columns: [
+                IntColumn<_Person>(
+                  fieldName: 'id',
+                  header: const ColumnHeader(
+                    text: 'Id',
+                    showAggregations: true,
+                  ),
+                  value: (row) => row.id,
+                  xsCols: 12,
+                  aggregations: const [
+                    AggregateCriteria(
+                      fieldName: 'id',
+                      aggregation: Aggregations.sum,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(GridFooter<_Person>), findsOneWidget);
+    expect(find.textContaining('6'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #14. Date/time columns offered sum, and aggregate footers used hardcoded dark colors. WidgetColumn aggregations and `allowAggregations` were already fixed in earlier PRs.

## Changes
- Remove sum from `DateTimeColumn` and `TimeOfDayColumn`
- Footer/group footer use theme surface colors and `onSurface` text
- `formatResult` format argument is optional; footers call it without a dummy `null`

## Tests
- DateTime/TimeOfDay aggregations exclude sum
- Footer shows the formatted sum of `id` values

Closes #14