### PR TITLE
fix(grid): complete OData mapping and rename endsWidth

### DIFF
--- a/client_filtering/lib/src/enums.dart
+++ b/client_filtering/lib/src/enums.dart
@@ -67,12 +67,16 @@ enum Logic implements IEnum {
   greaterThanOrEqualTo(5),
   contains(6),
   notContains(7),
-  endsWidth(8),
+  endsWith(8),
   startsWith(9),
   notEqual(10),
   notEndsWith(12),
   notStartsWith(11),
   between(13);
+
+  /// Typo kept as a public alias so existing call sites keep compiling.
+  @Deprecated('Use Logic.endsWith')
+  static const Logic endsWidth = Logic.endsWith;
 
   @override
   final int value;
@@ -99,7 +103,7 @@ enum Logic implements IEnum {
         return ClientFilteringLocalizedMessages.contains;
       case Logic.notContains:
         return ClientFilteringLocalizedMessages.notContains;
-      case Logic.endsWidth:
+      case Logic.endsWith:
         return ClientFilteringLocalizedMessages.endsWith;
       case Logic.startsWith:
         return ClientFilteringLocalizedMessages.startsWith;

--- a/client_filtering/lib/src/load_criteria.dart
+++ b/client_filtering/lib/src/load_criteria.dart
@@ -223,7 +223,7 @@ class LoadCriteria with IJsonable {
             return !value.contains(cValue);
           }).toList();
           break;
-        case Logic.endsWidth:
+        case Logic.endsWith:
           items = items.where((e) {
             final dynamic value = getFieldValue(criteria.fieldName, e);
             final dynamic cValue = criteria.values.isEmpty

--- a/client_filtering/test/logic_endswith_test.dart
+++ b/client_filtering/test/logic_endswith_test.dart
@@ -1,0 +1,10 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Logic.endsWith is the canonical ends-with operator at value 8', () {
+    expect(Logic.endsWith.value, 8);
+    expect(Logic.fromInt(8), Logic.endsWith);
+    expect(Logic.endsWidth, Logic.endsWith);
+  });
+}

--- a/responsive_data_grid/lib/src/extensions.dart
+++ b/responsive_data_grid/lib/src/extensions.dart
@@ -17,56 +17,50 @@ extension FilterCriteriaExtensions on List<FilterCriteria<dynamic>> {
   String toOdata() {
     if (isEmpty) return "";
 
-    String filter = '';
-    forEach((e) {
-      if (filter.isNotEmpty) {
-        if (e.op == Operators.or) {
-          filter += " OR ";
-        } else {
-          filter += " AND ";
-        }
+    final buffer = StringBuffer();
+    for (final e in this) {
+      if (buffer.isNotEmpty) {
+        buffer.write(e.op == Operators.or ? ' OR ' : ' AND ');
       }
+      buffer.write(_odataClause(e));
+    }
+    return buffer.toString();
+  }
 
-      if (e.logicalOperator == Logic.endsWidth) {
-        filter +=
-            " endsWidth(${escapeFieldName(e.fieldName)}, '${e.values.first}')";
-      } else if (e.logicalOperator == Logic.contains) {
-        filter +=
-            " contains(${escapeFieldName(e.fieldName)}, '${e.values.first}')";
-      } else if (e.logicalOperator == Logic.notContains) {
-        filter +=
-            " not contains(${escapeFieldName(e.fieldName)}, '${e.values.first}')";
-      } else if (e.logicalOperator == Logic.startsWith) {
-        filter +=
-            " startsWith(${escapeFieldName(e.fieldName)}, '${e.values.first}')";
-      } else if (e.logicalOperator == Logic.between) {
-        filter += " ge ${e.values.first} and le ${e.values.last}";
-      } else {
-        filter += "${escapeFieldName(e.fieldName)} ";
-        switch (e.logicalOperator) {
-          case Logic.equals:
-            filter += "eq";
-            break;
-          case Logic.greaterThan:
-            filter += "gt";
-            break;
-          case Logic.greaterThanOrEqualTo:
-            filter += "ge";
-            break;
-          case Logic.lessThan:
-            filter += "lt";
-            break;
-          case Logic.lessThanOrEqualTo:
-            filter += "le";
-            break;
-          default:
-            throw UnimplementedError();
-        }
-        filter += " ${e.values.first}";
-      }
-    });
+  String _odataClause(FilterCriteria<dynamic> e) {
+    final field = escapeFieldName(e.fieldName);
+    final value = e.values.isEmpty ? '' : e.values.first;
+    final quoted = "'$value'";
 
-    return filter;
+    switch (e.logicalOperator) {
+      case Logic.equals:
+        return '$field eq $value';
+      case Logic.notEqual:
+        return '$field ne $value';
+      case Logic.greaterThan:
+        return '$field gt $value';
+      case Logic.greaterThanOrEqualTo:
+        return '$field ge $value';
+      case Logic.lessThan:
+        return '$field lt $value';
+      case Logic.lessThanOrEqualTo:
+        return '$field le $value';
+      case Logic.contains:
+        return 'contains($field, $quoted)';
+      case Logic.notContains:
+        return 'not contains($field, $quoted)';
+      case Logic.startsWith:
+        return 'startswith($field, $quoted)';
+      case Logic.endsWith:
+        return 'endswith($field, $quoted)';
+      case Logic.notStartsWith:
+        return 'not startswith($field, $quoted)';
+      case Logic.notEndsWith:
+        return 'not endswith($field, $quoted)';
+      case Logic.between:
+        final last = e.values.length > 1 ? e.values.last : value;
+        return '$field ge $value and $field le $last';
+    }
   }
 
   String escapeFieldName(String fieldName) => fieldName.replaceAll("'", "''");

--- a/responsive_data_grid/lib/src/filters/string.dart
+++ b/responsive_data_grid/lib/src/filters/string.dart
@@ -61,8 +61,8 @@ class DataGridStringColumnFilterState<TItem extends Object>
               child: Text(Logic.startsWith.toString()),
             ),
             DropdownMenuItem(
-              value: Logic.endsWidth,
-              child: Text(Logic.endsWidth.toString()),
+              value: Logic.endsWith,
+              child: Text(Logic.endsWith.toString()),
             ),
             DropdownMenuItem(
               value: Logic.equals,

--- a/responsive_data_grid/test/odata_mapping_test.dart
+++ b/responsive_data_grid/test/odata_mapping_test.dart
@@ -1,0 +1,68 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+FilterCriteria<dynamic> _filter(
+  Logic logic, {
+  String field = 'Name',
+  List<dynamic> values = const ['Ada'],
+}) {
+  return FilterCriteria<dynamic>(
+    fieldName: field,
+    op: Operators.and,
+    logicalOperator: logic,
+    values: values,
+  );
+}
+
+String _odata(Logic logic, {String field = 'Name', List<dynamic>? values}) {
+  return [_filter(logic, field: field, values: values ?? const ['Ada'])]
+      .toOdata();
+}
+
+void main() {
+  test('toOdata maps notEqual, notStartsWith, and notEndsWith', () {
+    expect(_odata(Logic.notEqual), contains('ne'));
+    expect(_odata(Logic.notEqual), contains('Name'));
+
+    final notStarts = _odata(Logic.notStartsWith).toLowerCase();
+    expect(notStarts, contains('not startswith('));
+    expect(notStarts, contains('name'));
+
+    final notEnds = _odata(Logic.notEndsWith).toLowerCase();
+    expect(notEnds, contains('not endswith('));
+    expect(notEnds, contains('name'));
+  });
+
+  test('toOdata emits OData endswith, not endsWidth', () {
+    final text = _odata(Logic.endsWith).toLowerCase();
+    expect(text, contains('endswith('));
+    expect(text, isNot(contains('endswidth')));
+  });
+
+  test('toOdata emits OData startswith', () {
+    expect(_odata(Logic.startsWith).toLowerCase(), contains('startswith('));
+  });
+
+  test('toOdata between includes the field on both comparisons', () {
+    final text = _odata(
+      Logic.between,
+      field: 'Age',
+      values: const [1, 10],
+    );
+    expect(text, contains('Age ge 1'));
+    expect(text, contains('Age le 10'));
+  });
+
+  test('every Logic value produces OData without throwing', () {
+    for (final logic in Logic.values) {
+      final values = logic == Logic.between ? <dynamic>[1, 10] : <dynamic>['Ada'];
+      expect(
+        () => _odata(logic, values: values),
+        returnsNormally,
+        reason: '$logic should map to OData',
+      );
+      expect(_odata(logic, values: values), isNotEmpty);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #18. Filter-to-OData mapping threw for several operators, emitted invalid `endsWidth(`, and dropped the field name from `between`.

## Changes
- Map every `Logic` value to valid OData (`ne`, `startswith`/`endswith`, `not ...`)
- `between` is `field ge min and field le max`
- Rename `Logic.endsWidth` to `Logic.endsWith` with a deprecated alias (JSON value 8 unchanged)

## Tests
- OData clauses for notEqual, notStartsWith, notEndsWith, endswith, startswith, between
- Every `Logic` value produces OData without throwing
- `Logic.endsWith` is value 8 and aliases `endsWidth`

Closes #18