### PR TITLE
fix(client_filtering): page groups instead of splitting them

### DIFF
--- a/client_filtering/lib/src/list_response.dart
+++ b/client_filtering/lib/src/list_response.dart
@@ -42,29 +42,52 @@ class ListResponse<T> extends SimpleListResponse<T> {
     var items = criteria.filterItems(data: data, getFieldValue: getFieldValue);
     items = criteria.orderItems(items: items, getFieldValue: getFieldValue);
 
-    //Create data page
+    //Create Groups from the full filtered set, then page groups (not rows)
+    // so a group is not split across pages.
     List<T> pageItems;
-    if (criteria.skip != null && criteria.take != null) {
-      pageItems = items.skip(criteria.skip!).take(criteria.take!).toList();
-    } else if (criteria.skip != null) {
-      pageItems = items.skip(criteria.skip!).toList();
-    } else if (criteria.take != null) {
-      pageItems = items.take(criteria.take!).toList();
-    } else {
-      pageItems = List<T>.from(items);
-    }
-
-    //Create Groups
     List<GroupResult> groupResults;
+    int totalCount;
     if (criteria.groupBy == null || criteria.groupBy!.isEmpty) {
       groupResults = List<GroupResult>.empty();
+      if (criteria.skip != null && criteria.take != null) {
+        pageItems = items.skip(criteria.skip!).take(criteria.take!).toList();
+      } else if (criteria.skip != null) {
+        pageItems = items.skip(criteria.skip!).toList();
+      } else if (criteria.take != null) {
+        pageItems = items.take(criteria.take!).toList();
+      } else {
+        pageItems = List<T>.from(items);
+      }
+      totalCount = items.length;
     } else {
-      groupResults = criteria.groupItems(
+      final allGroups = criteria.groupItems(
         criteria: criteria.groupBy!.first,
-        items: pageItems,
+        items: items,
         allItems: items,
         getFieldValue: getFieldValue,
       );
+      totalCount = allGroups.length;
+      if (criteria.skip != null && criteria.take != null) {
+        groupResults = allGroups
+            .skip(criteria.skip!)
+            .take(criteria.take!)
+            .toList();
+      } else if (criteria.skip != null) {
+        groupResults = allGroups.skip(criteria.skip!).toList();
+      } else if (criteria.take != null) {
+        groupResults = allGroups.take(criteria.take!).toList();
+      } else {
+        groupResults = allGroups;
+      }
+      final groupValues = groupResults.map((g) => g.value).toSet();
+      final groupField = criteria.groupBy!.first.fieldName;
+      pageItems = items
+          .where(
+            (e) => groupValues.contains(
+              getFieldValue(groupField, e)?.toString(),
+            ),
+          )
+          .toList();
     }
 
     //Create overall aggregates
@@ -84,7 +107,7 @@ class ListResponse<T> extends SimpleListResponse<T> {
     }
 
     return ListResponse<T>(
-      totalCount: items.length,
+      totalCount: totalCount,
       items: pageItems,
       groups: groupResults,
       aggregates: aggregates,

--- a/client_filtering/test/group_paging_test.dart
+++ b/client_filtering/test/group_paging_test.dart
@@ -1,0 +1,51 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Person {
+  final String dept;
+  final String name;
+
+  const _Person(this.dept, this.name);
+}
+
+void main() {
+  final data = [
+    for (final dept in ['A', 'B', 'C', 'D'])
+      for (var i = 0; i < 2; i++) _Person(dept, '$dept$i'),
+  ];
+
+  LoadCriteria groupedCriteria({required int skip, required int take}) {
+    return LoadCriteria(
+      skip: skip,
+      take: take,
+      groupBy: const [
+        GroupCriteria(fieldName: 'dept', aggregates: []),
+      ],
+    );
+  }
+
+  test('fromData groups the full filtered set then pages groups', () {
+    final result = ListResponse.fromData(
+      data: data,
+      criteria: groupedCriteria(skip: 0, take: 2),
+      getFieldValue: (field, item) => item.dept,
+    );
+
+    expect(result.totalCount, 4);
+    expect(result.groups.map((g) => g.value), ['A', 'B']);
+    expect(result.items.map((e) => e.dept).toSet(), {'A', 'B'});
+    expect(result.items, hasLength(4));
+  });
+
+  test('fromData page 2 returns the next groups, not leftover rows of group A', () {
+    final result = ListResponse.fromData(
+      data: data,
+      criteria: groupedCriteria(skip: 2, take: 2),
+      getFieldValue: (field, item) => item.dept,
+    );
+
+    expect(result.totalCount, 4);
+    expect(result.groups.map((g) => g.value), ['C', 'D']);
+    expect(result.items.map((e) => e.dept).toSet(), {'C', 'D'});
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #30. Client-side grouping paged rows first, then grouped only that page, so group headers were page-local and a group could split across pages.

## Changes
- `ListResponse.fromData` groups the full filtered set
- skip/take page groups when `groupBy` is set; `totalCount` is the group count
- Each paged group includes all of its rows

## Tests
- Page 1 with take 2 returns the first two groups and all of their rows
- Page 2 returns the next groups, not leftover rows of group A

Closes #30