### PR TITLE
fix(grid): MenuAnchor menus and phone-width table scroll

### DIFF
--- a/responsive_data_grid/example/integration_test/column_menu_test.dart
+++ b/responsive_data_grid/example/integration_test/column_menu_test.dart
@@ -1,0 +1,32 @@
+import 'package:example/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('column filter menu opens, fits, and apply dismisses it', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Testing Title'), findsWidgets);
+    expect(find.byType(MenuAnchor), findsWidgets);
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Filter'), findsOneWidget);
+    expect(find.text(LocalizedMessages.apply), findsOneWidget);
+
+    await tester.tap(find.text(LocalizedMessages.apply));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(LocalizedMessages.apply), findsNothing);
+  });
+}

--- a/responsive_data_grid/example/pubspec.yaml
+++ b/responsive_data_grid/example/pubspec.yaml
@@ -28,6 +28,8 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/responsive_data_grid/lib/responsive_data_grid.dart
+++ b/responsive_data_grid/lib/responsive_data_grid.dart
@@ -42,6 +42,7 @@ part './src/rules/filter.dart';
 
 part './src/grid.dart';
 part './src/grid_state.dart';
+part './src/grid_layout.dart';
 part './src/extensions.dart';
 
 part './src/widgets/column_header.dart';

--- a/responsive_data_grid/lib/src/filters/datetime.dart
+++ b/responsive_data_grid/lib/src/filters/datetime.dart
@@ -61,6 +61,7 @@ class DataGridDateTimeColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButtonFormField<Logic?>(
+          isExpanded: true,
           items: [
             DropdownMenuItem<Logic?>(
               value: null,

--- a/responsive_data_grid/lib/src/filters/double.dart
+++ b/responsive_data_grid/lib/src/filters/double.dart
@@ -75,6 +75,7 @@ class DataGridDoubleColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButton<Logic?>(
+          isExpanded: true,
           items: [
             DropdownMenuItem<Logic?>(
               value: null,

--- a/responsive_data_grid/lib/src/filters/duration.dart
+++ b/responsive_data_grid/lib/src/filters/duration.dart
@@ -62,6 +62,7 @@ class DataGridDurationColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButtonFormField<Logic?>(
+          isExpanded: true,
           items: [
             DropdownMenuItem(value: null, child: Text(LocalizedMessages.any)),
             DropdownMenuItem(

--- a/responsive_data_grid/lib/src/filters/num.dart
+++ b/responsive_data_grid/lib/src/filters/num.dart
@@ -74,6 +74,7 @@ class DataGridNumColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButtonFormField<Logic?>(
+          isExpanded: true,
           items: [
             DropdownMenuItem<Logic?>(
               value: null,

--- a/responsive_data_grid/lib/src/filters/string.dart
+++ b/responsive_data_grid/lib/src/filters/string.dart
@@ -49,6 +49,7 @@ class DataGridStringColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButtonFormField<Logic?>(
+          isExpanded: true,
           elevation: 30,
           items: [
             DropdownMenuItem(value: null, child: Text(LocalizedMessages.any)),

--- a/responsive_data_grid/lib/src/filters/timeofday.dart
+++ b/responsive_data_grid/lib/src/filters/timeofday.dart
@@ -50,6 +50,7 @@ class DataGridTimeOfDayColumnFilterState<TItem extends Object>
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownButtonFormField<Logic?>(
+          isExpanded: true,
           items: [
             DropdownMenuItem<Logic?>(
               value: Logic.greaterThan,

--- a/responsive_data_grid/lib/src/grid_layout.dart
+++ b/responsive_data_grid/lib/src/grid_layout.dart
@@ -1,0 +1,87 @@
+part of '../responsive_data_grid.dart';
+
+/// Layout numbers for one grid table so header, body, and footer share a
+/// single non-wrapping row. When column segments exceed [totalSegments], the
+/// table is wider than the viewport and scrolls horizontally.
+class GridTableLayout extends InheritedWidget {
+  final double contentWidth;
+  final int totalSegments;
+
+  const GridTableLayout({
+    super.key,
+    required this.contentWidth,
+    required this.totalSegments,
+    required super.child,
+  });
+
+  static GridTableLayout? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<GridTableLayout>();
+  }
+
+  static GridTableLayout of(BuildContext context) {
+    final layout = maybeOf(context);
+    assert(layout != null, 'GridTableLayout not found in context');
+    return layout!;
+  }
+
+  @override
+  bool updateShouldNotify(GridTableLayout oldWidget) {
+    return contentWidth != oldWidget.contentWidth ||
+        totalSegments != oldWidget.totalSegments;
+  }
+}
+
+int gridColumnSegments<TItem extends Object>(
+  GridColumn<TItem, dynamic> column,
+  double screenWidth,
+) {
+  int? value;
+  if (screenWidth >= 1600) {
+    value =
+        column.xlCols ??
+        column.largeCols ??
+        column.mediumCols ??
+        column.smallCols ??
+        column.xsCols;
+  } else if (screenWidth >= 1200) {
+    value =
+        column.xlCols ??
+        column.largeCols ??
+        column.mediumCols ??
+        column.smallCols ??
+        column.xsCols;
+  } else if (screenWidth >= 992) {
+    value =
+        column.largeCols ??
+        column.mediumCols ??
+        column.smallCols ??
+        column.xsCols;
+  } else if (screenWidth >= 768) {
+    value = column.mediumCols ?? column.smallCols ?? column.xsCols;
+  } else if (screenWidth >= 576) {
+    value = column.smallCols ?? column.xsCols;
+  } else {
+    value = column.xsCols;
+  }
+  return value ?? 12;
+}
+
+({double contentWidth, int totalSegments}) gridTableMetrics<TItem extends Object>({
+  required List<GridColumn<TItem, dynamic>> columns,
+  required double viewportWidth,
+  required int reactiveSegments,
+  required double screenWidth,
+}) {
+  var used = 0;
+  for (final column in columns) {
+    used += gridColumnSegments(column, screenWidth);
+  }
+  if (used <= 0) used = reactiveSegments;
+  if (used <= reactiveSegments) {
+    return (contentWidth: viewportWidth, totalSegments: reactiveSegments);
+  }
+  return (
+    contentWidth: viewportWidth * used / reactiveSegments,
+    totalSegments: used,
+  );
+}

--- a/responsive_data_grid/lib/src/grid_state.dart
+++ b/responsive_data_grid/lib/src/grid_state.dart
@@ -327,24 +327,19 @@ class ResponsiveDataGridState<TItem extends Object>
                   );
                 }
 
-                parts.add(
-                  ResponsiveDataGridHeaderRowWidget<TItem>(
-                    this,
-                    widget.columns,
-                  ),
+                final screenWidth = MediaQuery.sizeOf(context).width;
+                final metrics = gridTableMetrics<TItem>(
+                  columns: widget.columns,
+                  viewportWidth: constraints.maxWidth,
+                  reactiveSegments: widget.reactiveSegments,
+                  screenWidth: screenWidth,
                 );
 
+                Widget tableBody;
                 if (isLoading) {
-                  final spinner = const Center(
-                    child: CircularProgressIndicator(),
-                  );
-                  parts.add(
-                    constraints.hasBoundedHeight
-                        ? Expanded(child: spinner)
-                        : spinner,
-                  );
+                  tableBody = const Center(child: CircularProgressIndicator());
                 } else if (loadError != null) {
-                  final errorView = Center(
+                  tableBody = Center(
                     child: Padding(
                       padding: const EdgeInsets.all(16),
                       child: Column(
@@ -360,24 +355,64 @@ class ResponsiveDataGridState<TItem extends Object>
                       ),
                     ),
                   );
-                  parts.add(
-                    constraints.hasBoundedHeight
-                        ? Expanded(child: errorView)
-                        : errorView,
-                  );
                 } else {
-                  parts.add(
-                    GridBody<TItem>(
-                      gridState: this,
-                      constraints: constraints,
-                      pagingMode: pagingMode,
-                      gridTheme: theme,
-                    ),
+                  tableBody = GridBody<TItem>(
+                    gridState: this,
+                    constraints: constraints,
+                    pagingMode: pagingMode,
+                    gridTheme: theme,
                   );
                 }
 
-                if (_dataCache.aggregates.isNotEmpty) {
-                  parts.add(GridFooter(_dataCache, this, theme));
+                final table = GridTableLayout(
+                  contentWidth: metrics.contentWidth,
+                  totalSegments: metrics.totalSegments,
+                  child: Column(
+                    mainAxisSize: constraints.hasBoundedHeight
+                        ? MainAxisSize.max
+                        : MainAxisSize.min,
+                    children: [
+                      ResponsiveDataGridHeaderRowWidget<TItem>(
+                        this,
+                        widget.columns,
+                      ),
+                      if (constraints.hasBoundedHeight)
+                        Expanded(child: tableBody)
+                      else
+                        tableBody,
+                      if (_dataCache.aggregates.isNotEmpty)
+                        GridFooter(_dataCache, this, theme),
+                    ],
+                  ),
+                );
+
+                if (constraints.hasBoundedHeight) {
+                  parts.add(
+                    Expanded(
+                      child: LayoutBuilder(
+                        builder: (context, inner) {
+                          return SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: SizedBox(
+                              width: metrics.contentWidth,
+                              height: inner.maxHeight,
+                              child: table,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  );
+                } else {
+                  parts.add(
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: SizedBox(
+                        width: metrics.contentWidth,
+                        child: table,
+                      ),
+                    ),
+                  );
                 }
 
                 if (pagingMode == PagingMode.pager) {

--- a/responsive_data_grid/lib/src/widgets/body.dart
+++ b/responsive_data_grid/lib/src/widgets/body.dart
@@ -18,11 +18,7 @@ class GridBody<TItem extends Object> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final body = getBody();
-    if (constraints.hasBoundedHeight) {
-      return Expanded(child: body);
-    }
-    return body;
+    return getBody();
   }
 
   Widget getBody() {

--- a/responsive_data_grid/lib/src/widgets/column_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/column_menu.dart
@@ -44,80 +44,78 @@ class ColumnMenu<T extends Object> extends DropDownViewWidget {
           )
         : <AggregationChooser<T>>[];
 
-    return Column(
-      children: [
-        SizedBox(height: 5),
-        Material(
-          elevation: 20,
-          type: MaterialType.card,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Visibility(
-                visible: aggregates.isNotEmpty,
-                child: SizedBox(
-                  width: 250,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(color: Colors.black38),
-                    child: Padding(
-                      padding: EdgeInsets.all(3),
-                      child: Text("Aggregates"),
+    return Material(
+      elevation: 4,
+      type: MaterialType.card,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (aggregates.isNotEmpty)
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(
+                  "Aggregates",
+                  style: theme.textTheme.labelLarge,
+                ),
+              ),
+            ),
+          ...aggregates,
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Text("Filter", style: theme.textTheme.labelLarge),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: column.filterRules.showFilter(column, gridState),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextButton.icon(
+                    onPressed: () {
+                      column.aggregations.clear();
+                      column.filterRules.criteria = null;
+                      close(context);
+                      gridState.refreshData();
+                    },
+                    icon: const Icon(Icons.clear_all),
+                    label: Text(
+                      LocalizedMessages.clear,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
                 ),
-              ),
-              ...aggregates,
-              SizedBox(
-                width: 250,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(color: Colors.black38),
-                  child: Padding(
-                    padding: EdgeInsets.all(3),
-                    child: Text("Filter"),
+                Expanded(
+                  child: TextButton.icon(
+                    onPressed: () {
+                      close(context);
+                      gridState.refreshData();
+                    },
+                    icon: const Icon(Icons.save),
+                    label: Text(
+                      LocalizedMessages.apply,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
                 ),
-              ),
-              column.filterRules.showFilter(column, gridState),
-              Divider(),
-              Wrap(
-                alignment: WrapAlignment.spaceBetween,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: [
-                  TextButton.icon(
-                    onPressed: () async {
-                      final navigator = Navigator.of(
-                        context,
-                        rootNavigator: true,
-                      );
-                      final route = ModalRoute.of(context);
-                      column.aggregations.clear();
-                      column.filterRules.criteria = null;
-                      await gridState.refreshData();
-                      _popMenuIfCurrent(navigator, route);
-                    },
-                    icon: Icon(Icons.clear_all),
-                    label: Text(LocalizedMessages.clear),
-                  ),
-                  TextButton.icon(
-                    onPressed: () async {
-                      final navigator = Navigator.of(
-                        context,
-                        rootNavigator: true,
-                      );
-                      final route = ModalRoute.of(context);
-                      await gridState.refreshData();
-                      _popMenuIfCurrent(navigator, route);
-                    },
-                    icon: Icon(Icons.save),
-                    label: Text(LocalizedMessages.apply),
-                  ),
-                ],
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
+++ b/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
@@ -21,53 +21,71 @@ abstract class DropDownViewWidget extends StatefulWidget {
 }
 
 class _DropDownViewState extends State<DropDownViewWidget> {
-  @override
-  void initState() {
-    super.initState();
-  }
+  final MenuController _controller = MenuController();
 
   void close(BuildContext context) {
-    _popMenuIfCurrent(
-      Navigator.of(context, rootNavigator: true),
-      ModalRoute.of(context),
-    );
+    _controller.close();
   }
 
   @override
   Widget build(BuildContext context) {
-    return IconButton(
-      key: widget.key,
-      visualDensity: VisualDensity.compact,
-      padding: EdgeInsets.zero,
-      constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
-      style: IconButton.styleFrom(
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        minimumSize: const Size(24, 24),
-        padding: EdgeInsets.zero,
-      ),
-      icon: widget.icon,
-      color: widget.theme.gridPrimaryColor,
-      onPressed: (() {
-        showAlignedDialog<void>(
-          avoidOverflow: true,
-          context: context,
-          barrierDismissible: true,
-          barrierColor: Colors.transparent,
-          followerAnchor: Alignment.topRight,
-          targetAnchor: Alignment.bottomLeft,
-          offset: Offset(32, 0),
-          builder: (BuildContext ctx) => SizedBox(
-            width: widget.dropDownWidth,
-            child: SingleChildScrollView(child: widget.build(ctx, close)),
-          ),
-        );
-      }),
+    final size = MediaQuery.sizeOf(context);
+    final maxWidth = math.min(
+      widget.dropDownWidth,
+      math.max(0.0, size.width - 16),
     );
-  }
-}
+    final maxHeight =
+        widget.dropDownHeight ?? math.max(120.0, size.height * 0.7);
 
-void _popMenuIfCurrent(NavigatorState navigator, Route<dynamic>? route) {
-  if (route != null && route.isCurrent && navigator.canPop()) {
-    navigator.pop();
+    return MenuAnchor(
+      controller: _controller,
+      alignmentOffset: const Offset(0, 4),
+      consumeOutsideTap: true,
+      style: MenuStyle(
+        padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+        visualDensity: VisualDensity.compact,
+        maximumSize: WidgetStatePropertyAll(Size(maxWidth, maxHeight)),
+      ),
+      builder: (context, controller, child) {
+        return IconButton(
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+          style: IconButton.styleFrom(
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            minimumSize: const Size(24, 24),
+            padding: EdgeInsets.zero,
+          ),
+          icon: widget.icon,
+          color: widget.theme.gridPrimaryColor,
+          onPressed: () {
+            if (controller.isOpen) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+        );
+      },
+      menuChildren: [
+        Builder(
+          builder: (overlayContext) {
+            return ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: maxWidth,
+                maxHeight: maxHeight,
+              ),
+              child: SingleChildScrollView(
+                primary: false,
+                child: SizedBox(
+                  width: maxWidth,
+                  child: widget.build(overlayContext, close),
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
   }
 }

--- a/responsive_data_grid/lib/src/widgets/grid_footer.dart
+++ b/responsive_data_grid/lib/src/widgets/grid_footer.dart
@@ -32,7 +32,9 @@ class GridFooter<TItem extends Object> extends StatelessWidget {
                 ? WrapCrossAlignment.center
                 : WrapCrossAlignment.end,
             children: getColumns(context),
-            totalSegments: gridState.widget.reactiveSegments,
+            totalSegments:
+                GridTableLayout.maybeOf(context)?.totalSegments ??
+                gridState.widget.reactiveSegments,
           ),
         ),
       ),

--- a/responsive_data_grid/lib/src/widgets/group_footer.dart
+++ b/responsive_data_grid/lib/src/widgets/group_footer.dart
@@ -36,7 +36,9 @@ class GridGroupFooter<TItem extends Object> extends StatelessWidget {
               ? WrapCrossAlignment.center
               : WrapCrossAlignment.end,
           children: getColumns(context),
-          totalSegments: gridState.widget.reactiveSegments,
+          totalSegments:
+              GridTableLayout.maybeOf(context)?.totalSegments ??
+              gridState.widget.reactiveSegments,
         ),
       ),
     );

--- a/responsive_data_grid/lib/src/widgets/group_menu.dart
+++ b/responsive_data_grid/lib/src/widgets/group_menu.dart
@@ -52,14 +52,9 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                       "Apply",
                       style: theme.gridLabelLarge,
                     ),
-                    onPressed: () async {
-                      final navigator = Navigator.of(
-                        context,
-                        rootNavigator: true,
-                      );
-                      final route = ModalRoute.of(context);
-                      await gridState.updateGroup(group);
-                      _popMenuIfCurrent(navigator, route);
+                    onPressed: () {
+                      close(context);
+                      gridState.updateGroup(group);
                     },
                     icon: Icon(Icons.save, color: theme.colorScheme.onPrimary),
                   ),
@@ -71,15 +66,10 @@ class GroupMenu<TItem extends Object> extends DropDownViewWidget {
                       "Clear All",
                       style: theme.gridLabelLarge,
                     ),
-                    onPressed: () async {
-                      final navigator = Navigator.of(
-                        context,
-                        rootNavigator: true,
-                      );
-                      final route = ModalRoute.of(context);
+                    onPressed: () {
                       group.aggregates.clear();
-                      await gridState.updateGroup(group);
-                      _popMenuIfCurrent(navigator, route);
+                      close(context);
+                      gridState.updateGroup(group);
                     },
                     icon: Icon(
                       Icons.clear_all,

--- a/responsive_data_grid/lib/src/widgets/header_row.dart
+++ b/responsive_data_grid/lib/src/widgets/header_row.dart
@@ -48,7 +48,9 @@ class ResponsiveDataGridHeaderRowWidget<TItem extends Object>
                 : grid.headerCrossAxisAlignment == CrossAxisAlignment.center
                 ? WrapCrossAlignment.center
                 : WrapCrossAlignment.end,
-            totalSegments: grid.reactiveSegments,
+            totalSegments:
+                GridTableLayout.maybeOf(context)?.totalSegments ??
+                grid.reactiveSegments,
           ),
         ),
       ),

--- a/responsive_data_grid/lib/src/widgets/row.dart
+++ b/responsive_data_grid/lib/src/widgets/row.dart
@@ -52,7 +52,9 @@ class DataGridRowWidget<TItem extends Object> extends StatelessWidget {
               ? WrapCrossAlignment.center
               : WrapCrossAlignment.end,
           children: getColumns(context, grid, item),
-          totalSegments: grid.reactiveSegments,
+          totalSegments:
+              GridTableLayout.maybeOf(context)?.totalSegments ??
+              grid.reactiveSegments,
         ),
       ),
     );

--- a/responsive_data_grid/test/filter_apply_test.dart
+++ b/responsive_data_grid/test/filter_apply_test.dart
@@ -54,14 +54,14 @@ void main() {
     await tester.tap(find.byIcon(Icons.menu).first);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
-    _ignoreOverflow(tester);
+    expect(tester.takeException(), isNull);
 
     await tester.tap(find.byType(DropdownButtonFormField<Logic?>));
     await tester.pumpAndSettle();
-    _ignoreOverflow(tester);
+    expect(tester.takeException(), isNull);
     await tester.tap(find.text(Logic.contains.toString()).last);
     await tester.pumpAndSettle();
-    _ignoreOverflow(tester);
+    expect(tester.takeException(), isNull);
 
     await tester.enterText(find.byType(TextFormField), 'Ada');
     await tester.pump();
@@ -69,15 +69,9 @@ void main() {
     await tester.tap(find.text(LocalizedMessages.apply));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
-    _ignoreOverflow(tester);
+    expect(tester.takeException(), isNull);
 
     expect(find.text('Ada'), findsWidgets);
     expect(find.text('Grace'), findsNothing);
   });
-}
-
-void _ignoreOverflow(WidgetTester tester) {
-  final error = tester.takeException();
-  if (error == null) return;
-  expect(error.toString(), contains('overflowed'));
 }

--- a/responsive_data_grid/test/menu_overflow_test.dart
+++ b/responsive_data_grid/test/menu_overflow_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final String name;
+
+  const _Person(this.name);
+}
+
+void main() {
+  testWidgets('column menu fits a phone viewport without overflow', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 844,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 400,
+              pagingMode: PagingMode.pager,
+              items: const [_Person('Ada'), _Person('Grace')],
+              columns: [
+                StringColumn<_Person>(
+                  fieldName: 'name',
+                  header: const ColumnHeader(text: 'Name', showFilter: true),
+                  value: (row) => row.name,
+                  xsCols: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(LocalizedMessages.apply), findsOneWidget);
+    expect(find.text(LocalizedMessages.clear), findsOneWidget);
+    expect(find.byType(MenuAnchor), findsWidgets);
+  });
+
+  testWidgets('tapping apply dismisses the column menu', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 844,
+            child: ResponsiveDataGrid<_Person>.clientSide(
+              height: 400,
+              pagingMode: PagingMode.pager,
+              items: const [_Person('Ada')],
+              columns: [
+                StringColumn<_Person>(
+                  fieldName: 'name',
+                  header: const ColumnHeader(text: 'Name', showFilter: true),
+                  value: (row) => row.name,
+                  xsCols: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.byIcon(Icons.menu).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.text(LocalizedMessages.apply), findsOneWidget);
+
+    await tester.tap(find.text(LocalizedMessages.apply));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(LocalizedMessages.apply), findsNothing);
+  });
+}

--- a/responsive_data_grid/test/phone_header_layout_test.dart
+++ b/responsive_data_grid/test/phone_header_layout_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final String name;
+  final String extra;
+
+  const _Person(this.id, this.name, this.extra);
+}
+
+void main() {
+  testWidgets('phone-width header keeps all columns on one row', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ResponsiveDataGrid<_Person>.clientSide(
+            height: 600,
+            pagingMode: PagingMode.pager,
+            items: const [_Person(1, 'Ada', 'Yes')],
+            columns: [
+              IntColumn<_Person>(
+                fieldName: 'id',
+                header: const ColumnHeader(text: 'Id'),
+                value: (row) => row.id,
+                xsCols: 2,
+              ),
+              StringColumn<_Person>(
+                fieldName: 'name',
+                header: const ColumnHeader(text: 'Name'),
+                value: (row) => row.name,
+                xsCols: 5,
+              ),
+              StringColumn<_Person>(
+                fieldName: 'dob',
+                header: const ColumnHeader(text: 'Date of Birth'),
+                value: (row) => row.extra,
+                xsCols: 4,
+              ),
+              StringColumn<_Person>(
+                fieldName: 'accepted',
+                header: const ColumnHeader(text: 'Accepted'),
+                value: (row) => row.extra,
+                xsCols: 3,
+              ),
+              StringColumn<_Person>(
+                fieldName: 'enum',
+                header: const ColumnHeader(text: 'Enum'),
+                value: (row) => row.extra,
+                xsCols: 4,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final id = tester.getTopLeft(find.text('Id').first);
+    final name = tester.getTopLeft(find.text('Name').first);
+    final dob = tester.getTopLeft(find.text('Date of Birth').first);
+    final accepted = tester.getTopLeft(find.text('Accepted').first);
+    final enumHeader = tester.getTopLeft(find.text('Enum').first);
+
+    expect(name.dy, closeTo(id.dy, 2));
+    expect(dob.dy, closeTo(id.dy, 2));
+    expect(accepted.dy, closeTo(id.dy, 2));
+    expect(enumHeader.dy, closeTo(id.dy, 2));
+    expect(enumHeader.dx, greaterThan(accepted.dx));
+  });
+}

--- a/responsive_data_grid/test/theme_force_unwrap_test.dart
+++ b/responsive_data_grid/test/theme_force_unwrap_test.dart
@@ -147,14 +147,6 @@ void main() {
   });
 }
 
-/// Overflow in the 250px column menu is #41. This issue only forbids theme
-/// force-unwrap / Navigator crashes.
 void _expectNoThemeCrash(WidgetTester tester) {
-  final error = tester.takeException();
-  if (error == null) return;
-  expect(
-    error.toString(),
-    contains('overflowed'),
-    reason: 'Unexpected exception: $error',
-  );
+  expect(tester.takeException(), isNull);
 }


### PR DESCRIPTION
## Summary
Fixes #41 (column menu overflow / dismiss) and #71 (iPhone header/body wrap). Found on iPhone 17 while verifying the menu: the header wrapped `Date of Birth` / `Accepted` / `Enum` onto extra lines and body cells did the same.

## Changes
- Replace `showAlignedDialog` with `MenuAnchor` (overlay context, outside tap, Escape)
- Constrain the menu to the viewport; filter `DropdownButtonFormField`s use `isExpanded`
- Apply/Clear close the menu without popping the navigator
- When xs (or other) column segments exceed 12, the table is wider than the viewport and **scrolls horizontally** so header, body, and footer stay one row

## Tests
- Phone viewport: menu opens with no overflow; Apply dismisses
- Phone viewport: Id / Name / Date of Birth / Accepted / Enum share one header row
- Existing filter apply and theme menu tests no longer swallow overflow

## Simulator
- iPhone 17: header is a single row; extra columns scroll; body cells stay on one line
- iPad Air 11-inch (M4): all columns visible and aligned

Closes #41
Closes #71