### PR TITLE
fix(grid): stop MenuAnchor nested-scroll intrinsic crash

### DIFF
--- a/responsive_data_grid/example/integration_test/column_menu_test.dart
+++ b/responsive_data_grid/example/integration_test/column_menu_test.dart
@@ -16,7 +16,11 @@ void main() {
     expect(find.text('Testing Title'), findsWidgets);
     expect(find.byType(MenuAnchor), findsWidgets);
 
-    await tester.tap(find.byIcon(Icons.menu).first);
+    final columnMenus = find.descendant(
+      of: find.byType(ResponsiveDataGridHeaderRowWidget<ExampleData>),
+      matching: find.byIcon(Icons.menu),
+    );
+    await tester.tap(columnMenus.first);
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);

--- a/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
+++ b/responsive_data_grid/lib/src/widgets/dropdown_view_widget.dart
@@ -70,18 +70,11 @@ class _DropDownViewState extends State<DropDownViewWidget> {
       menuChildren: [
         Builder(
           builder: (overlayContext) {
-            return ConstrainedBox(
-              constraints: BoxConstraints(
-                maxWidth: maxWidth,
-                maxHeight: maxHeight,
-              ),
-              child: SingleChildScrollView(
-                primary: false,
-                child: SizedBox(
-                  width: maxWidth,
-                  child: widget.build(overlayContext, close),
-                ),
-              ),
+            // MenuAnchor measures intrinsic width/height. A scroll viewport
+            // cannot report those, so the panel itself must be the scroller.
+            return SizedBox(
+              width: maxWidth,
+              child: widget.build(overlayContext, close),
             );
           },
         ),

--- a/responsive_data_grid/test/menu_overflow_test.dart
+++ b/responsive_data_grid/test/menu_overflow_test.dart
@@ -44,8 +44,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     await tester.tap(find.byIcon(Icons.menu).first);
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
+    await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
     expect(find.text(LocalizedMessages.apply), findsOneWidget);
@@ -86,13 +85,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     await tester.tap(find.byIcon(Icons.menu).first);
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
+    await tester.pumpAndSettle();
     expect(find.text(LocalizedMessages.apply), findsOneWidget);
 
     await tester.tap(find.text(LocalizedMessages.apply));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
     expect(find.text(LocalizedMessages.apply), findsNothing);


### PR DESCRIPTION
## Summary
Hotfix for #72. Opening a column menu on iPhone 17 threw:

`RenderShrinkWrappingViewport does not support returning intrinsic dimensions` from `MenuAnchor` → `IntrinsicWidth` → our nested `SingleChildScrollView`.

## Changes
- Menu content is a fixed-width `SizedBox`; the `MenuAnchor` panel is the scroller
- Example integration test taps a **header** column menu (not the group menu) and Apply-dismisses on device

## Tests
- Package widget tests
- `example/integration_test/column_menu_test.dart` on iPhone 17 simulator — passed