### PR TITLE
test(grid): keep header on one row across bootstrap breakpoints

### DIFF
--- a/responsive_data_grid/test/breakpoint_layout_test.dart
+++ b/responsive_data_grid/test/breakpoint_layout_test.dart
@@ -80,39 +80,33 @@ void _expectSingleHeaderRow(WidgetTester tester) {
   final id = tester.getTopLeft(find.text('Id').first);
   for (final label in ['Name', 'Date of Birth', 'Accepted', 'Enum']) {
     final pos = tester.getTopLeft(find.text(label).first);
-    expect(pos.dy, closeTo(id.dy, 2), reason: '$label wrapped off the header row');
+    expect(
+      pos.dy,
+      closeTo(id.dy, 2),
+      reason: '$label wrapped off the header row',
+    );
   }
-  expect(tester.getTopLeft(find.text('Enum').first).dx, greaterThan(tester.getTopLeft(find.text('Id').first).dx));
+  expect(
+    tester.getTopLeft(find.text('Enum').first).dx,
+    greaterThan(tester.getTopLeft(find.text('Id').first).dx),
+  );
 }
 
 void main() {
-  testWidgets('xs 400: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(400, 700));
-    _expectSingleHeaderRow(tester);
-  });
+  // Bootstrap cutovers: xs<576, sm>=576, md>=768, lg>=992, xl>=1200, xxl>=1600.
+  const sizes = <String, Size>{
+    'xs 400': Size(400, 700),
+    'sm 600': Size(600, 700),
+    'md 800': Size(800, 700),
+    'lg 1000': Size(1000, 700),
+    'xl 1300': Size(1300, 800),
+    'xxl 1700': Size(1700, 900),
+  };
 
-  testWidgets('sm 600: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(600, 700));
-    _expectSingleHeaderRow(tester);
-  });
-
-  testWidgets('md 800: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(800, 700));
-    _expectSingleHeaderRow(tester);
-  });
-
-  testWidgets('lg 1000: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(1000, 700));
-    _expectSingleHeaderRow(tester);
-  });
-
-  testWidgets('xl 1300: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(1300, 800));
-    _expectSingleHeaderRow(tester);
-  });
-
-  testWidgets('xxl 1700: header stays one row', (tester) async {
-    await _pumpAt(tester, const Size(1700, 900));
-    _expectSingleHeaderRow(tester);
-  });
+  for (final entry in sizes.entries) {
+    testWidgets('${entry.key}: header stays one row', (tester) async {
+      await _pumpAt(tester, entry.value);
+      _expectSingleHeaderRow(tester);
+    });
+  }
 }

--- a/responsive_data_grid/test/breakpoint_layout_test.dart
+++ b/responsive_data_grid/test/breakpoint_layout_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:responsive_data_grid/responsive_data_grid.dart';
+
+class _Person {
+  final int id;
+  final String name;
+  final String extra;
+
+  const _Person(this.id, this.name, this.extra);
+}
+
+List<GridColumn<_Person, dynamic>> _columns() {
+  return [
+    IntColumn<_Person>(
+      fieldName: 'id',
+      header: const ColumnHeader(text: 'Id'),
+      value: (row) => row.id,
+      xsCols: 2,
+    ),
+    StringColumn<_Person>(
+      fieldName: 'name',
+      header: const ColumnHeader(text: 'Name'),
+      value: (row) => row.name,
+      xsCols: 5,
+      mediumCols: 2,
+    ),
+    StringColumn<_Person>(
+      fieldName: 'dob',
+      header: const ColumnHeader(text: 'Date of Birth'),
+      value: (row) => row.extra,
+      xsCols: 4,
+      mediumCols: 3,
+    ),
+    StringColumn<_Person>(
+      fieldName: 'accepted',
+      header: const ColumnHeader(text: 'Accepted'),
+      value: (row) => row.extra,
+      xsCols: 3,
+      mediumCols: 2,
+    ),
+    StringColumn<_Person>(
+      fieldName: 'enum',
+      header: const ColumnHeader(text: 'Enum'),
+      value: (row) => row.extra,
+      xsCols: 4,
+      mediumCols: 2,
+    ),
+  ];
+}
+
+Future<void> _pumpAt(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: size.width,
+          height: size.height,
+          child: ResponsiveDataGrid<_Person>.clientSide(
+            height: size.height - 24,
+            pagingMode: PagingMode.pager,
+            items: const [_Person(1, 'Ada', 'Yes')],
+            columns: _columns(),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void _expectSingleHeaderRow(WidgetTester tester) {
+  expect(tester.takeException(), isNull);
+  final id = tester.getTopLeft(find.text('Id').first);
+  for (final label in ['Name', 'Date of Birth', 'Accepted', 'Enum']) {
+    final pos = tester.getTopLeft(find.text(label).first);
+    expect(pos.dy, closeTo(id.dy, 2), reason: '$label wrapped off the header row');
+  }
+  expect(tester.getTopLeft(find.text('Enum').first).dx, greaterThan(tester.getTopLeft(find.text('Id').first).dx));
+}
+
+void main() {
+  testWidgets('xs 400: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(400, 700));
+    _expectSingleHeaderRow(tester);
+  });
+
+  testWidgets('sm 600: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(600, 700));
+    _expectSingleHeaderRow(tester);
+  });
+
+  testWidgets('md 800: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(800, 700));
+    _expectSingleHeaderRow(tester);
+  });
+
+  testWidgets('lg 1000: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(1000, 700));
+    _expectSingleHeaderRow(tester);
+  });
+
+  testWidgets('xl 1300: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(1300, 800));
+    _expectSingleHeaderRow(tester);
+  });
+
+  testWidgets('xxl 1700: header stays one row', (tester) async {
+    await _pumpAt(tester, const Size(1700, 900));
+    _expectSingleHeaderRow(tester);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds widget tests at Bootstrap xs/sm/md/lg/xl/xxl widths (400, 600, 800, 1000, 1300, 1700) asserting column headers stay on a single row.
- Locks in the #72 table layout: columns that exceed 12 segments scroll horizontally instead of wrapping.

## Test plan
- [x] `flutter test test/breakpoint_layout_test.dart` (6 passed)
- [x] Resized the macOS example through 500 / 640 / 850 / 1100 / 1300 / 1700 and confirmed header+body stay one row; extra columns at xs/sm are reachable via horizontal scroll; Enum column menu still opens at xs.