### PR TITLE
fix(client_filtering): evaluate Operators.or and DateTime between

### DIFF
--- a/client_filtering/lib/src/load_criteria.dart
+++ b/client_filtering/lib/src/load_criteria.dart
@@ -113,208 +113,90 @@ class LoadCriteria with IJsonable {
     required Iterable<T> data,
     required dynamic Function(String fieldName, T item) getFieldValue,
   }) {
-    Iterable<T> items = List<T>.from(data);
-
-    for (final criteria in filterBy) {
-      if (criteria.op == Operators.or) {
-        throw UnsupportedError("Or is not supported in Dart.");
-      }
-
-      switch (criteria.logicalOperator) {
-        case Logic.equals:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-
-            return criteria.values.contains(value);
-          });
-          break;
-        case Logic.lessThan:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null || cValue == null) return false;
-
-            if (value is DateTime && cValue is DateTime) {
-              return value.compareTo(cValue) < 0;
-            }
-
-            return (value < cValue) as bool;
-          });
-          break;
-        case Logic.greaterThan:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null || cValue == null) return false;
-
-            if (value is DateTime && cValue is DateTime) {
-              return value.compareTo(cValue) > 0;
-            }
-
-            return (value > cValue) as bool;
-          }).toList();
-
-          break;
-        case Logic.lessThanOrEqualTo:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null || cValue == null) return false;
-
-            if (value is DateTime && cValue is DateTime) {
-              return value.compareTo(cValue) <= 0;
-            }
-
-            return (value <= cValue) as bool;
-          });
-          break;
-        case Logic.greaterThanOrEqualTo:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null || cValue == null) return false;
-
-            if (value is DateTime && cValue is DateTime) {
-              return value.compareTo(cValue) >= 0;
-            }
-
-            return (value >= cValue) as bool;
-          });
-          break;
-        case Logic.contains:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return value.contains(cValue);
-          });
-          break;
-        case Logic.notContains:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return !value.contains(cValue);
-          }).toList();
-          break;
-        case Logic.endsWith:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return value.endsWith(cValue);
-          });
-          break;
-        case Logic.startsWith:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return value.startsWith(cValue);
-          }).toList();
-          break;
-        case Logic.notEqual:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            return !criteria.values.contains(value);
-          });
-          break;
-        case Logic.notEndsWith:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return !value.endsWith(cValue);
-          });
-          break;
-        case Logic.notStartsWith:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            if (value == null ||
-                cValue == null ||
-                value is! String ||
-                cValue is! String) {
-              return false;
-            }
-
-            return !value.startsWith(cValue);
-          });
-          break;
-        case Logic.between:
-          items = items.where((e) {
-            final dynamic value = getFieldValue(criteria.fieldName, e);
-            final dynamic cValue1 = criteria.values.isEmpty
-                ? null
-                : criteria.values.first;
-            final dynamic cValue2 = criteria.values.length > 1
-                ? criteria.values.last
-                : null;
-            if (value == null || cValue1 == null || cValue2 == null) {
-              return false;
-            }
-
-            return (value >= cValue1) as bool && (value <= cValue2) as bool;
-          });
-          break;
-      }
+    if (filterBy.isEmpty) {
+      return List<T>.from(data);
     }
 
-    return items;
+    // Match .NET ApplyFilterPredicates: first clause is the seed, each
+    // following clause joins with that clause's Operators (AND/OR).
+    return data.where((item) {
+      var result = _matches(filterBy.first, item, getFieldValue);
+      for (final criteria in filterBy.skip(1)) {
+        final matched = _matches(criteria, item, getFieldValue);
+        result = criteria.op == Operators.or
+            ? result || matched
+            : result && matched;
+      }
+      return result;
+    });
+  }
+
+  bool _matches<T>(
+    FilterCriteria<dynamic> criteria,
+    T item,
+    dynamic Function(String fieldName, T item) getFieldValue,
+  ) {
+    final dynamic value = getFieldValue(criteria.fieldName, item);
+    final values = criteria.values;
+    final dynamic first = values.isEmpty ? null : values.first;
+    final dynamic last = values.length > 1 ? values.last : null;
+
+    switch (criteria.logicalOperator) {
+      case Logic.equals:
+        return values.contains(value);
+      case Logic.notEqual:
+        return !values.contains(value);
+      case Logic.lessThan:
+        final lt = _compare(value, first);
+        return lt != null && lt < 0;
+      case Logic.lessThanOrEqualTo:
+        final lte = _compare(value, first);
+        return lte != null && lte <= 0;
+      case Logic.greaterThan:
+        final gt = _compare(value, first);
+        return gt != null && gt > 0;
+      case Logic.greaterThanOrEqualTo:
+        final gte = _compare(value, first);
+        return gte != null && gte >= 0;
+      case Logic.between:
+        final lo = _compare(value, first);
+        final hi = _compare(value, last);
+        return lo != null && hi != null && lo >= 0 && hi <= 0;
+      case Logic.contains:
+        return value is String && first is String && value.contains(first);
+      case Logic.notContains:
+        return value is String && first is String && !value.contains(first);
+      case Logic.startsWith:
+        return value is String && first is String && value.startsWith(first);
+      case Logic.notStartsWith:
+        return value is String && first is String && !value.startsWith(first);
+      case Logic.endsWith:
+        return value is String && first is String && value.endsWith(first);
+      case Logic.notEndsWith:
+        return value is String && first is String && !value.endsWith(first);
+    }
+  }
+
+  int? _compare(dynamic left, dynamic right) {
+    if (left == null || right == null) {
+      return null;
+    }
+    if (left is DateTime && right is DateTime) {
+      return left.compareTo(right);
+    }
+    if (left is TimeOfDay && right is TimeOfDay) {
+      return (left.hour * 60 + left.minute).compareTo(
+        right.hour * 60 + right.minute,
+      );
+    }
+    if (left is Comparable && right is Comparable) {
+      try {
+        return left.compareTo(right);
+      } on TypeError {
+        return null;
+      }
+    }
+    return null;
   }
 
   Iterable<T> orderItems<T>({

--- a/client_filtering/test/filter_items_test.dart
+++ b/client_filtering/test/filter_items_test.dart
@@ -1,0 +1,255 @@
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Row {
+  final int id;
+  final String name;
+  final DateTime? dob;
+  final bool accepted;
+
+  const _Row(this.id, this.name, this.dob, this.accepted);
+}
+
+dynamic _field(String name, _Row row) {
+  switch (name) {
+    case 'id':
+      return row.id;
+    case 'name':
+      return row.name;
+    case 'dob':
+      return row.dob;
+    case 'accepted':
+      return row.accepted;
+    default:
+      throw ArgumentError.value(name, 'name');
+  }
+}
+
+FilterCriteria<T> _filter<T>({
+  required String field,
+  required Logic logic,
+  required List<T> values,
+  Operators op = Operators.and,
+}) {
+  return FilterCriteria<T>(
+    fieldName: field,
+    op: op,
+    logicalOperator: logic,
+    values: values,
+  );
+}
+
+List<_Row> _apply(LoadCriteria criteria, List<_Row> data) {
+  return criteria
+      .filterItems(data: data, getFieldValue: _field)
+      .toList(growable: false);
+}
+
+void main() {
+  final ada = _Row(1, 'Ada', DateTime.utc(1977, 6, 17), true);
+  final grace = _Row(2, 'Grace', DateTime.utc(1985, 1, 2), false);
+  final alan = _Row(3, 'Alan', null, true);
+  final rows = [ada, grace, alan];
+
+  group('Operators.or', () {
+    test('unions two field predicates instead of throwing', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.equals, values: ['Ada']),
+          _filter(
+            field: 'name',
+            logic: Logic.equals,
+            values: ['Alan'],
+            op: Operators.or,
+          ),
+        ],
+      );
+
+      expect(_apply(criteria, rows).map((r) => r.name), ['Ada', 'Alan']);
+    });
+
+    test('joins left-associatively with AND then OR', () {
+      // (id == 1 AND name == Ada) OR name == Grace
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.equals, values: [1]),
+          _filter(
+            field: 'name',
+            logic: Logic.equals,
+            values: ['Ada'],
+            op: Operators.and,
+          ),
+          _filter(
+            field: 'name',
+            logic: Logic.equals,
+            values: ['Grace'],
+            op: Operators.or,
+          ),
+        ],
+      );
+
+      expect(_apply(criteria, rows).map((r) => r.name), ['Ada', 'Grace']);
+    });
+  });
+
+  group('Logic matrix — strings', () {
+    test('equals', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.equals, values: ['Ada']),
+        ],
+      );
+      expect(_apply(criteria, rows), [ada]);
+    });
+
+    test('notEqual', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.notEqual, values: ['Ada']),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.name), ['Grace', 'Alan']);
+    });
+
+    test('contains', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.contains, values: ['ra']),
+        ],
+      );
+      expect(_apply(criteria, rows), [grace]);
+    });
+
+    test('notContains', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.notContains, values: ['ce']),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.name), ['Ada', 'Alan']);
+    });
+
+    test('startsWith', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.startsWith, values: ['A']),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.name), ['Ada', 'Alan']);
+    });
+
+    test('notStartsWith', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.notStartsWith, values: ['A']),
+        ],
+      );
+      expect(_apply(criteria, rows), [grace]);
+    });
+
+    test('endsWith', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.endsWith, values: ['n']),
+        ],
+      );
+      expect(_apply(criteria, rows), [alan]);
+    });
+
+    test('notEndsWith', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.notEndsWith, values: ['n']),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.name), ['Ada', 'Grace']);
+    });
+  });
+
+  group('Logic matrix — ints', () {
+    test('lessThan', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.lessThan, values: [2]),
+        ],
+      );
+      expect(_apply(criteria, rows), [ada]);
+    });
+
+    test('lessThanOrEqualTo', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.lessThanOrEqualTo, values: [2]),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.id), [1, 2]);
+    });
+
+    test('greaterThan', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.greaterThan, values: [2]),
+        ],
+      );
+      expect(_apply(criteria, rows), [alan]);
+    });
+
+    test('greaterThanOrEqualTo', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.greaterThanOrEqualTo, values: [2]),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.id), [2, 3]);
+    });
+
+    test('between is inclusive', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'id', logic: Logic.between, values: [1, 2]),
+        ],
+      );
+      expect(_apply(criteria, rows).map((r) => r.id), [1, 2]);
+    });
+  });
+
+  group('Logic matrix — DateTime', () {
+    test('between includes endpoints and skips nulls', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(
+            field: 'dob',
+            logic: Logic.between,
+            values: [DateTime.utc(1977, 6, 17), DateTime.utc(1980, 1, 1)],
+          ),
+        ],
+      );
+      expect(_apply(criteria, rows), [ada]);
+    });
+
+    test('greaterThan compares DateTimes', () {
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(
+            field: 'dob',
+            logic: Logic.greaterThan,
+            values: [DateTime.utc(1980, 1, 1)],
+          ),
+        ],
+      );
+      expect(_apply(criteria, rows), [grace]);
+    });
+  });
+
+  group('null handling', () {
+    test('string operators drop null field values', () {
+      final withNullName = [ada, const _Row(4, '', null, false)];
+      final criteria = LoadCriteria(
+        filterBy: [
+          _filter(field: 'name', logic: Logic.contains, values: ['A']),
+        ],
+      );
+      expect(_apply(criteria, withNullName), [ada]);
+    });
+  });
+}

--- a/dotnet/ClientFilteringTests/ClientFilteringTests.cs
+++ b/dotnet/ClientFilteringTests/ClientFilteringTests.cs
@@ -265,4 +265,50 @@ public class Tests
         results.Should().HaveCount(1);
         results.First().Name.Should().BeEquivalentTo("Test User");
     }
+
+    [Fact]
+    public void FilterByOrUnionsPredicates()
+    {
+        var contacts = new List<Contact>
+        {
+            new Contact(
+                Id: Guid.NewGuid().ToString(),
+                Name: "Ada",
+                DateOfBirth: new DateTime(1977, 6, 17)
+            ),
+            new Contact(
+                Id: Guid.NewGuid().ToString(),
+                Name: "Grace",
+                DateOfBirth: new DateTime(1985, 1, 2)
+            ),
+            new Contact(
+                Id: Guid.NewGuid().ToString(),
+                Name: "Alan",
+                DateOfBirth: new DateTime(1912, 6, 23)
+            ),
+        };
+
+        var criteria = new LoadCriteria
+        {
+            FilterBy = new[]
+            {
+                new FilterCriteria
+                {
+                    FieldName = nameof(Contact.Name),
+                    Relation = RelationalOperators.Equals,
+                    Values = new[] { "Ada" },
+                },
+                new FilterCriteria
+                {
+                    FieldName = nameof(Contact.Name),
+                    Op = LogicalOperators.Or,
+                    Relation = RelationalOperators.Equals,
+                    Values = new[] { "Alan" },
+                },
+            },
+        };
+
+        var results = contacts.AsQueryable().ApplyLoadCriteria(criteria).ToArray();
+        results.Select(c => c.Name).Should().BeEquivalentTo("Ada", "Alan");
+    }
 }


### PR DESCRIPTION
## Summary
- Dart `filterItems` now joins clauses left-associatively with `Operators.and` / `Operators.or`, matching .NET `ApplyFilterPredicates`, instead of throwing `UnsupportedError("Or is not supported in Dart.")`.
- Comparison operators (including `Logic.between`) use `compareTo` for `DateTime` / `TimeOfDay`, so the date filter UI no longer crashes on apply.
- Tests cover OR, mixed AND/OR, and the full `Logic` matrix on strings, ints, and DateTime. .NET gets a matching OR union test. Column filters still write `Operators.and`; cross-column OR UX remains #20. `Between` is still Dart/JS-only (#35).

Closes #34

## Test plan
- [x] `flutter test` in `client_filtering/` (26 passed, including new `filter_items_test.dart`)
- [x] `dart analyze` in `client_filtering/` (no issues)
- [x] `DOTNET_ROLL_FORWARD=LatestMajor dotnet test --filter FilterByOrUnionsPredicates` (passed)