### PR TITLE
fix(client_filtering): align Dart, .NET, and JS LoadCriteria JSON

### DIFF
--- a/client_filtering/lib/client_filtering.dart
+++ b/client_filtering/lib/client_filtering.dart
@@ -9,6 +9,7 @@ import 'package:intl/intl.dart' as intl;
 import 'package:material_ui/material_ui.dart' show TimeOfDay;
 
 part './src/enums.dart';
+part './src/json_util.dart';
 part './src/filter_criteria.dart';
 part './src/load_criteria.dart';
 part './src/order_criteria.dart';

--- a/client_filtering/lib/src/aggregate_criteria.dart
+++ b/client_filtering/lib/src/aggregate_criteria.dart
@@ -8,8 +8,8 @@ class AggregateCriteria with IJsonable {
 
   factory AggregateCriteria.fromJson(Map<String, dynamic> json) =>
       AggregateCriteria(
-        fieldName: json['fieldName'].toString(),
-        aggregation: Aggregations.fromInt(json["aggregation"] as int),
+        fieldName: jsonValue(json, 'fieldName').toString(),
+        aggregation: Aggregations.fromJson(jsonValue(json, 'aggregation')),
       );
 
   @override

--- a/client_filtering/lib/src/enums.dart
+++ b/client_filtering/lib/src/enums.dart
@@ -19,6 +19,19 @@ enum Aggregations implements IEnum {
   factory Aggregations.fromInt(num i) =>
       Aggregations.values.firstWhere((x) => x.value == i);
 
+  factory Aggregations.fromJson(dynamic value) => parseWireEnum(
+    value: value,
+    fromInt: Aggregations.fromInt,
+    typeName: 'Aggregations',
+    names: {
+      'sum': Aggregations.sum,
+      'average': Aggregations.average,
+      'maximum': Aggregations.maximum,
+      'minimum': Aggregations.minimum,
+      'count': Aggregations.count,
+    },
+  );
+
   @override
   String toString() {
     switch (this) {
@@ -47,6 +60,13 @@ enum Operators implements IEnum {
 
   factory Operators.fromInt(num i) =>
       Operators.values.firstWhere((x) => x.value == i);
+
+  factory Operators.fromJson(dynamic value) => parseWireEnum(
+    value: value,
+    fromInt: Operators.fromInt,
+    typeName: 'Operators',
+    names: {'and': Operators.and, 'or': Operators.or},
+  );
 
   @override
   String toString() {
@@ -83,6 +103,28 @@ enum Logic implements IEnum {
   const Logic(this.value);
 
   factory Logic.fromInt(num i) => Logic.values.firstWhere((x) => x.value == i);
+
+  factory Logic.fromJson(dynamic value) => parseWireEnum(
+    value: value,
+    fromInt: Logic.fromInt,
+    typeName: 'Logic',
+    names: {
+      'equals': Logic.equals,
+      'lessthan': Logic.lessThan,
+      'greaterthan': Logic.greaterThan,
+      'lessthanorequalto': Logic.lessThanOrEqualTo,
+      'greaterthanorequalto': Logic.greaterThanOrEqualTo,
+      'contains': Logic.contains,
+      'notcontains': Logic.notContains,
+      'endswith': Logic.endsWith,
+      'endswidth': Logic.endsWith,
+      'startswith': Logic.startsWith,
+      'notequal': Logic.notEqual,
+      'notstartswith': Logic.notStartsWith,
+      'notendswith': Logic.notEndsWith,
+      'between': Logic.between,
+    },
+  );
 
   @override
   String toString() {
@@ -129,6 +171,17 @@ enum OrderDirections implements IEnum {
 
   factory OrderDirections.fromInt(num i) =>
       OrderDirections.values.firstWhere((x) => x.value == i);
+
+  factory OrderDirections.fromJson(dynamic value) => parseWireEnum(
+    value: value,
+    fromInt: OrderDirections.fromInt,
+    typeName: 'OrderDirections',
+    names: {
+      'notset': OrderDirections.notSet,
+      'ascending': OrderDirections.ascending,
+      'descending': OrderDirections.descending,
+    },
+  );
 
   @override
   String toString() {

--- a/client_filtering/lib/src/filter_criteria.dart
+++ b/client_filtering/lib/src/filter_criteria.dart
@@ -36,7 +36,7 @@ class FilterCriteria<TValue extends dynamic> with IJsonable {
         other.fieldName == fieldName &&
         other.op == op &&
         other.logicalOperator == logicalOperator &&
-        other.values == values;
+        listEquals(other.values, values);
   }
 
   @override
@@ -84,11 +84,13 @@ class FilterCriteria<TValue extends dynamic> with IJsonable {
     Map<String, dynamic> map,
   ) {
     return FilterCriteria(
-      fieldName: map['fieldName'].toString(),
-      op: Operators.fromInt(map['op'] as int),
-      logicalOperator: Logic.fromInt(map['logicalOperator'] as int),
-      values: (map['values'] as List)
-          .map((dynamic e) => _parseValue<TValue>(e as String))
+      fieldName: jsonValue(map, 'fieldName').toString(),
+      op: Operators.fromJson(jsonValue(map, 'op') ?? 1),
+      logicalOperator: Logic.fromJson(
+        jsonValue(map, 'logicalOperator', ['relation']),
+      ),
+      values: jsonList(jsonValue(map, 'values'))
+          .map((dynamic e) => _parseValue<TValue>(e.toString()))
           .toList(growable: true),
     );
   }
@@ -113,9 +115,7 @@ class FilterCriteria<TValue extends dynamic> with IJsonable {
         if (TValue == TimeOfDay) {
           return TimeOfDay.fromDateTime(DateTime.parse(value)) as TValue;
         }
-        throw UnsupportedError(
-          "The type ${TValue.toString()} is not supported for deserialization.",
-        );
+        return value as TValue;
     }
   }
 

--- a/client_filtering/lib/src/group_criteria.dart
+++ b/client_filtering/lib/src/group_criteria.dart
@@ -12,14 +12,13 @@ class GroupCriteria with IJsonable {
   });
 
   factory GroupCriteria.fromJson(Map<String, dynamic> json) => GroupCriteria(
-    fieldName: json['fieldName'].toString(),
-    direction: OrderDirections.fromInt(
-      (json['direction'] ?? json['directions']) as int,
+    fieldName: jsonValue(json, 'fieldName').toString(),
+    direction: OrderDirections.fromJson(
+      jsonValue(json, 'direction', ['directions']) ?? 1,
     ),
-    aggregates: (json["aggregates"] as List)
+    aggregates: jsonList(jsonValue(json, 'aggregates'))
         .map<AggregateCriteria>(
-          (dynamic model) =>
-              AggregateCriteria.fromJson(model as Map<String, dynamic>),
+          (dynamic model) => AggregateCriteria.fromJson(jsonMap(model)),
         )
         .toList(),
   );

--- a/client_filtering/lib/src/json_util.dart
+++ b/client_filtering/lib/src/json_util.dart
@@ -1,0 +1,77 @@
+part of '../client_filtering.dart';
+
+dynamic jsonValue(
+  Map<dynamic, dynamic> json,
+  String camel, [
+  List<String> aliases = const [],
+]) {
+  bool matches(Object? key, String name) =>
+      key is String && key.toLowerCase() == name.toLowerCase();
+
+  for (final name in [camel, ...aliases]) {
+    for (final entry in json.entries) {
+      if (matches(entry.key, name)) {
+        return entry.value;
+      }
+    }
+  }
+  return null;
+}
+
+List<dynamic> jsonList(dynamic raw) => raw is List ? raw : const <dynamic>[];
+
+Map<String, dynamic> jsonMap(dynamic raw) =>
+    Map<String, dynamic>.from(raw as Map);
+
+T parseWireEnum<T extends IEnum>({
+  required dynamic value,
+  required T Function(num) fromInt,
+  required Map<String, T> names,
+  required String typeName,
+}) {
+  if (value == null) {
+    throw FormatException('Missing $typeName');
+  }
+  if (value is num) {
+    return fromInt(value);
+  }
+  if (value is String) {
+    final asInt = int.tryParse(value);
+    if (asInt != null) {
+      return fromInt(asInt);
+    }
+    final key = value.toLowerCase().replaceAll(RegExp(r'[_\s]'), '');
+    final match = names[key];
+    if (match != null) {
+      return match;
+    }
+  }
+  throw FormatException('Cannot parse $typeName from $value');
+}
+
+List<GroupCriteria>? groupByFromJson(dynamic raw) {
+  if (raw == null) {
+    return null;
+  }
+  final groups = <GroupCriteria>[];
+
+  void add(dynamic node) {
+    if (node == null) {
+      return;
+    }
+    if (node is List) {
+      for (final child in node) {
+        add(child);
+      }
+      return;
+    }
+    if (node is Map) {
+      final map = jsonMap(node);
+      groups.add(GroupCriteria.fromJson(map));
+      add(jsonValue(map, 'subGroup'));
+    }
+  }
+
+  add(raw);
+  return groups;
+}

--- a/client_filtering/lib/src/load_criteria.dart
+++ b/client_filtering/lib/src/load_criteria.dart
@@ -20,34 +20,24 @@ class LoadCriteria with IJsonable {
        orderBy = orderBy ?? List<OrderCriteria>.empty(growable: true);
 
   factory LoadCriteria.fromJson(Map<String, dynamic> json) => LoadCriteria(
-    skip: json["skip"] as int?,
-    take: json["take"] as int?,
-    filterBy: (json["filterBy"] as List)
+    skip: (jsonValue(json, 'skip') as num?)?.toInt(),
+    take: (jsonValue(json, 'take') as num?)?.toInt(),
+    filterBy: jsonList(jsonValue(json, 'filterBy'))
         .map<FilterCriteria<dynamic>>(
-          (dynamic model) =>
-              FilterCriteria.fromJson<dynamic>(model as Map<String, dynamic>),
+          (dynamic model) => FilterCriteria.fromJson<dynamic>(jsonMap(model)),
         )
         .toList(),
-    orderBy: (json["orderBy"] as List)
+    orderBy: jsonList(jsonValue(json, 'orderBy'))
         .map<OrderCriteria>(
-          (dynamic model) =>
-              OrderCriteria.fromJson(model as Map<String, dynamic>),
+          (dynamic model) => OrderCriteria.fromJson(jsonMap(model)),
         )
         .toList(),
-    groupBy: json["groupBy"] == null
+    groupBy: groupByFromJson(jsonValue(json, 'groupBy')),
+    aggregates: jsonValue(json, 'aggregates') == null
         ? null
-        : (json["groupBy"] as List)
-              .map<GroupCriteria>(
-                (dynamic model) =>
-                    GroupCriteria.fromJson(model as Map<String, dynamic>),
-              )
-              .toList(),
-    aggregates: json["aggregates"] == null
-        ? null
-        : (json["aggregates"] as List)
+        : jsonList(jsonValue(json, 'aggregates'))
               .map<AggregateCriteria>(
-                (dynamic model) =>
-                    AggregateCriteria.fromJson(model as Map<String, dynamic>),
+                (dynamic model) => AggregateCriteria.fromJson(jsonMap(model)),
               )
               .toList(),
   );

--- a/client_filtering/lib/src/order_criteria.dart
+++ b/client_filtering/lib/src/order_criteria.dart
@@ -10,8 +10,10 @@ class OrderCriteria with IJsonable {
   });
 
   factory OrderCriteria.fromJson(Map<String, dynamic> json) => OrderCriteria(
-    fieldName: json['fieldName'].toString(),
-    direction: OrderDirections.fromInt(json['direction'] as int),
+    fieldName: jsonValue(json, 'fieldName').toString(),
+    direction: OrderDirections.fromJson(
+      jsonValue(json, 'direction', ['directions']) ?? 1,
+    ),
   );
 
   @override

--- a/client_filtering/test/load_criteria_contract_test.dart
+++ b/client_filtering/test/load_criteria_contract_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:client_filtering/client_filtering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Canonical V2 wire format: camelCase, int enums, groupBy as an array,
+/// filter relation field named `logicalOperator`.
+const canonicalJson = '''
+{
+  "skip": 10,
+  "take": 25,
+  "filterBy": [
+    {
+      "fieldName": "name",
+      "op": 1,
+      "logicalOperator": 1,
+      "values": ["Ada"]
+    },
+    {
+      "fieldName": "id",
+      "op": 2,
+      "logicalOperator": 10,
+      "values": ["2"]
+    }
+  ],
+  "orderBy": [
+    {
+      "fieldName": "name",
+      "direction": 1
+    }
+  ],
+  "groupBy": [
+    {
+      "fieldName": "name",
+      "direction": 2,
+      "aggregates": [
+        { "fieldName": "id", "aggregation": 5 }
+      ]
+    },
+    {
+      "fieldName": "accepted",
+      "direction": 1,
+      "aggregates": []
+    }
+  ],
+  "aggregates": [
+    { "fieldName": "id", "aggregation": 5 }
+  ]
+}
+''';
+
+/// Legacy .NET System.Text.Json shape (PascalCase, string enums, Relation,
+/// single nested GroupBy).
+const dotnetLegacyJson = '''
+{
+  "Skip": 10,
+  "Take": 25,
+  "FilterBy": [
+    {
+      "FieldName": "name",
+      "Op": "And",
+      "Relation": "Equals",
+      "Values": ["Ada"]
+    },
+    {
+      "FieldName": "id",
+      "Op": "Or",
+      "Relation": "NotEqual",
+      "Values": ["2"]
+    }
+  ],
+  "OrderBy": [
+    { "FieldName": "name", "Direction": "Ascending" }
+  ],
+  "GroupBy": {
+    "FieldName": "name",
+    "Direction": "Descending",
+    "Aggregates": [
+      { "FieldName": "id", "Aggregation": "Count" }
+    ],
+    "SubGroup": {
+      "FieldName": "accepted",
+      "Direction": "Ascending",
+      "Aggregates": []
+    }
+  },
+  "Aggregates": [
+    { "FieldName": "id", "Aggregation": "Count" }
+  ]
+}
+''';
+
+void _expectCanonical(LoadCriteria c) {
+  expect(c.skip, 10);
+  expect(c.take, 25);
+  expect(c.filterBy, hasLength(2));
+  expect(c.filterBy[0].fieldName, 'name');
+  expect(c.filterBy[0].op, Operators.and);
+  expect(c.filterBy[0].logicalOperator, Logic.equals);
+  expect(c.filterBy[0].values, ['Ada']);
+  expect(c.filterBy[1].fieldName, 'id');
+  expect(c.filterBy[1].op, Operators.or);
+  expect(c.filterBy[1].logicalOperator, Logic.notEqual);
+  expect(c.orderBy.single.fieldName, 'name');
+  expect(c.orderBy.single.direction, OrderDirections.ascending);
+  expect(c.groupBy, hasLength(2));
+  expect(c.groupBy![0].fieldName, 'name');
+  expect(c.groupBy![0].direction, OrderDirections.descending);
+  expect(c.groupBy![0].aggregates.single.aggregation, Aggregations.count);
+  expect(c.groupBy![1].fieldName, 'accepted');
+  expect(c.aggregates!.single.aggregation, Aggregations.count);
+}
+
+void main() {
+  test('parses canonical V2 JSON', () {
+    final c = LoadCriteria.fromJson(
+      jsonDecode(canonicalJson) as Map<String, dynamic>,
+    );
+    _expectCanonical(c);
+  });
+
+  test(
+    'parses legacy .NET JSON (PascalCase, string enums, nested GroupBy)',
+    () {
+      final c = LoadCriteria.fromJson(
+        jsonDecode(dotnetLegacyJson) as Map<String, dynamic>,
+      );
+      _expectCanonical(c);
+    },
+  );
+
+  test('toJson emits canonical keys and int enums', () {
+    final c = LoadCriteria.fromJson(
+      jsonDecode(canonicalJson) as Map<String, dynamic>,
+    );
+    final json = c.toJson();
+    expect(
+      json.keys,
+      containsAll([
+        'skip',
+        'take',
+        'filterBy',
+        'orderBy',
+        'groupBy',
+        'aggregates',
+      ]),
+    );
+    expect(json['filterBy'][0]['logicalOperator'], 1);
+    expect(json['filterBy'][0]['op'], 1);
+    expect(json['groupBy'], isA<List<dynamic>>());
+    expect((json['groupBy'] as List<dynamic>), hasLength(2));
+    expect(json['orderBy'][0]['direction'], 1);
+    expect(json.containsKey('GroupBy'), isFalse);
+  });
+
+  test('round-trips canonical JSON', () {
+    final original = LoadCriteria.fromJson(
+      jsonDecode(canonicalJson) as Map<String, dynamic>,
+    );
+    final restored = LoadCriteria.fromJson(
+      jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+    );
+    expect(restored, original);
+  });
+
+  test('missing filterBy and orderBy default to empty', () {
+    final c = LoadCriteria.fromJson({'skip': 0, 'take': 5});
+    expect(c.filterBy, isEmpty);
+    expect(c.orderBy, isEmpty);
+    expect(c.groupBy, isNull);
+    expect(c.aggregates, isNull);
+  });
+
+  test('Logic.fromJson accepts EndsWidth alias and Between', () {
+    expect(Logic.fromJson(8), Logic.endsWith);
+    expect(Logic.fromJson('EndsWidth'), Logic.endsWith);
+    expect(Logic.fromJson('endsWith'), Logic.endsWith);
+    expect(Logic.fromJson(13), Logic.between);
+    expect(Logic.fromJson('Between'), Logic.between);
+  });
+}

--- a/dotnet/ClientFiltering/Enums/RelationalOperators.cs
+++ b/dotnet/ClientFiltering/Enums/RelationalOperators.cs
@@ -38,4 +38,7 @@ public enum RelationalOperators
 
     [EnumMember]
     NotEndsWith = 12,
+
+    [EnumMember]
+    Between = 13,
 }

--- a/dotnet/ClientFiltering/Extensions/FilterCriteriaExtensions.cs
+++ b/dotnet/ClientFiltering/Extensions/FilterCriteriaExtensions.cs
@@ -186,6 +186,18 @@ public static class FilterCriteriaExtensions
                 if (criteria.Relation == RelationalOperators.NotEndsWith)
                     expression = Expression.Not(expression);
                 break;
+            case RelationalOperators.Between:
+                if (values.Length < 2)
+                {
+                    throw new InvalidOperationException(
+                        "Between requires two values."
+                    );
+                }
+                expression = Expression.AndAlso(
+                    Expression.GreaterThanOrEqual(property, values[0]),
+                    Expression.LessThanOrEqual(property, values[1])
+                );
+                break;
             default:
                 throw new ArgumentOutOfRangeException(
                     nameof(criteria),

--- a/dotnet/ClientFiltering/GlobalUsings.cs
+++ b/dotnet/ClientFiltering/GlobalUsings.cs
@@ -5,5 +5,7 @@ global using System.Globalization;
 global using System.Linq;
 global using System.Linq.Expressions;
 global using System.Runtime.Serialization;
+global using System.Text.Json;
 global using System.Text.Json.Serialization;
 global using ClientFiltering.Enums;
+global using ClientFiltering.Serialization;

--- a/dotnet/ClientFiltering/Models/AggregateCriteria.cs
+++ b/dotnet/ClientFiltering/Models/AggregateCriteria.cs
@@ -6,6 +6,6 @@ public record AggregateCriteria
     public required string FieldName { get; init; }
 
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(FlexibleEnumConverter<Aggregations>))]
     public required Aggregations Aggregation { get; init; }
 }

--- a/dotnet/ClientFiltering/Models/AggregateResult.cs
+++ b/dotnet/ClientFiltering/Models/AggregateResult.cs
@@ -7,7 +7,7 @@ public record AggregateResult
     public required string FieldName { get; init; }
 
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(FlexibleEnumConverter<Aggregations>))]
     public required Aggregations Aggregation { get; init; }
 
     [DataMember]

--- a/dotnet/ClientFiltering/Models/FilterCriteria.cs
+++ b/dotnet/ClientFiltering/Models/FilterCriteria.cs
@@ -1,6 +1,7 @@
 namespace ClientFiltering.Models;
 
 [DataContract]
+[JsonConverter(typeof(FilterCriteriaJsonConverter))]
 public record FilterCriteria
 {
     /// <summary>
@@ -13,14 +14,15 @@ public record FilterCriteria
     /// The operator
     /// </summary>
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(FlexibleEnumConverter<LogicalOperators>))]
     public LogicalOperators Op { get; init; } = LogicalOperators.And;
 
     /// <summary>
-    /// The logical operator for the function
+    /// The comparison operator. Serialized as <c>logicalOperator</c>.
     /// </summary>
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonPropertyName("logicalOperator")]
+    [JsonConverter(typeof(FlexibleEnumConverter<RelationalOperators>))]
     public RelationalOperators Relation { get; init; }
 
     /// <summary>

--- a/dotnet/ClientFiltering/Models/GroupCriteria.cs
+++ b/dotnet/ClientFiltering/Models/GroupCriteria.cs
@@ -7,7 +7,7 @@ public record GroupCriteria
     public required string FieldName { get; init; }
 
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(FlexibleEnumConverter<OrderDirections>))]
     public required OrderDirections Direction { get; init; }
 
     [DataMember]

--- a/dotnet/ClientFiltering/Models/LoadCriteria.cs
+++ b/dotnet/ClientFiltering/Models/LoadCriteria.cs
@@ -37,6 +37,7 @@ public record LoadCriteria
     /// </summary>
     /// <value></value>
     [DataMember]
+    [JsonConverter(typeof(GroupByJsonConverter))]
     public GroupCriteria? GroupBy { get; init; }
 
     /// <summary>

--- a/dotnet/ClientFiltering/Models/OrderCriteria.cs
+++ b/dotnet/ClientFiltering/Models/OrderCriteria.cs
@@ -16,6 +16,6 @@ public record OrderCriteria
     /// The direction to order it
     /// </summary>
     [DataMember]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(FlexibleEnumConverter<OrderDirections>))]
     public required OrderDirections Direction { get; init; }
 }

--- a/dotnet/ClientFiltering/Serialization/ClientFilteringJson.cs
+++ b/dotnet/ClientFiltering/Serialization/ClientFilteringJson.cs
@@ -1,0 +1,22 @@
+namespace ClientFiltering.Serialization;
+
+/// <summary>
+/// Serializer options for the V2 LoadCriteria wire contract: camelCase,
+/// integer enums, <c>logicalOperator</c>, and <c>groupBy</c> as an array.
+/// </summary>
+public static class ClientFilteringJson
+{
+    public static JsonSerializerOptions Options { get; } = CreateOptions();
+
+    public static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+        options.Converters.Add(new FlexibleEnumConverterFactory());
+        return options;
+    }
+}

--- a/dotnet/ClientFiltering/Serialization/FilterCriteriaJsonConverter.cs
+++ b/dotnet/ClientFiltering/Serialization/FilterCriteriaJsonConverter.cs
@@ -1,0 +1,94 @@
+namespace ClientFiltering.Serialization;
+
+using ClientFiltering.Models;
+
+public sealed class FilterCriteriaJsonConverter : JsonConverter<FilterCriteria>
+{
+    public override FilterCriteria Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+        var relation =
+            Property(root, "logicalOperator")
+            ?? Property(root, "relation")
+            ?? throw new JsonException("logicalOperator is required");
+
+        return new FilterCriteria
+        {
+            FieldName =
+                Property(root, "fieldName")?.GetString()
+                ?? throw new JsonException("fieldName is required"),
+            Op = ReadEnum(Property(root, "op"), LogicalOperators.And, options),
+            Relation = ReadEnum(relation, default(RelationalOperators), options),
+            Values = Property(root, "values") is { } values
+                ? values
+                    .EnumerateArray()
+                    .Select(v => v.ValueKind == JsonValueKind.Null ? null : v.ToString())
+                    .ToImmutableArray()
+                : ImmutableArray<string?>.Empty,
+        };
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        FilterCriteria value,
+        JsonSerializerOptions options
+    )
+    {
+        writer.WriteStartObject();
+        writer.WriteString("fieldName", value.FieldName);
+        writer.WriteNumber("op", (int)value.Op);
+        writer.WriteNumber("logicalOperator", (int)value.Relation);
+        writer.WritePropertyName("values");
+        writer.WriteStartArray();
+        foreach (var item in value.Values)
+        {
+            if (item is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(item);
+            }
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private static JsonElement? Property(JsonElement root, string name)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static T ReadEnum<T>(
+        JsonElement? element,
+        T fallback,
+        JsonSerializerOptions options
+    )
+        where T : struct, Enum
+    {
+        if (element is null)
+        {
+            return fallback;
+        }
+
+        var converter = new FlexibleEnumConverter<T>();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(element.Value.GetRawText());
+        var reader = new Utf8JsonReader(bytes);
+        reader.Read();
+        return converter.Read(ref reader, typeof(T), options);
+    }
+}

--- a/dotnet/ClientFiltering/Serialization/FlexibleEnumConverter.cs
+++ b/dotnet/ClientFiltering/Serialization/FlexibleEnumConverter.cs
@@ -1,0 +1,57 @@
+namespace ClientFiltering.Serialization;
+
+public sealed class FlexibleEnumConverter<T> : JsonConverter<T>
+    where T : struct, Enum
+{
+    public override T Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            return (T)Enum.ToObject(typeof(T), reader.GetInt32());
+        }
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var text = reader.GetString() ?? throw new JsonException($"Missing {typeof(T).Name}");
+            if (int.TryParse(text, out var numeric))
+            {
+                return (T)Enum.ToObject(typeof(T), numeric);
+            }
+
+            if (Enum.TryParse(text, ignoreCase: true, out T parsed))
+            {
+                return parsed;
+            }
+
+            if (
+                typeof(T) == typeof(RelationalOperators)
+                && text.Equals("EndsWith", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return (T)(object)RelationalOperators.EndsWidth;
+            }
+
+            throw new JsonException($"Cannot parse {typeof(T).Name} from '{text}'");
+        }
+
+        throw new JsonException($"Unexpected token {reader.TokenType} for {typeof(T).Name}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue((int)(object)value);
+}
+
+public sealed class FlexibleEnumConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsEnum;
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(FlexibleEnumConverter<>).MakeGenericType(typeToConvert);
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+}

--- a/dotnet/ClientFiltering/Serialization/GroupByJsonConverter.cs
+++ b/dotnet/ClientFiltering/Serialization/GroupByJsonConverter.cs
@@ -1,0 +1,68 @@
+namespace ClientFiltering.Serialization;
+
+using ClientFiltering.Models;
+
+/// <summary>
+/// Wire format is a <c>groupBy</c> array. Nested <see cref="GroupCriteria.SubGroup"/>
+/// is still accepted when deserializing a single object.
+/// </summary>
+public sealed class GroupByJsonConverter : JsonConverter<GroupCriteria?>
+{
+    public override GroupCriteria? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            var items =
+                JsonSerializer.Deserialize<List<GroupCriteria>>(ref reader, options) ?? [];
+            return Chain(items);
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            return JsonSerializer.Deserialize<GroupCriteria>(ref reader, options);
+        }
+
+        throw new JsonException($"Unexpected token {reader.TokenType} for groupBy");
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        GroupCriteria? value,
+        JsonSerializerOptions options
+    )
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStartArray();
+        for (var group = value; group is not null; group = group.SubGroup)
+        {
+            var item = group with { SubGroup = null };
+            JsonSerializer.Serialize(writer, item, options);
+        }
+        writer.WriteEndArray();
+    }
+
+    private static GroupCriteria? Chain(IReadOnlyList<GroupCriteria> items)
+    {
+        GroupCriteria? next = null;
+        for (var i = items.Count - 1; i >= 0; i--)
+        {
+            next = items[i] with { SubGroup = next };
+        }
+
+        return next;
+    }
+}

--- a/dotnet/ClientFilteringTests/LoadCriteriaContractTests.cs
+++ b/dotnet/ClientFilteringTests/LoadCriteriaContractTests.cs
@@ -1,0 +1,167 @@
+namespace ClientFilteringTests;
+
+using System.Linq;
+using System.Text.Json;
+using ClientFiltering.Enums;
+using ClientFiltering.Models;
+using ClientFiltering.Serialization;
+using FluentAssertions;
+using Xunit;
+
+public class LoadCriteriaContractTests
+{
+    private const string CanonicalJson = """
+        {
+          "skip": 10,
+          "take": 25,
+          "filterBy": [
+            {
+              "fieldName": "name",
+              "op": 1,
+              "logicalOperator": 1,
+              "values": ["Ada"]
+            },
+            {
+              "fieldName": "id",
+              "op": 2,
+              "logicalOperator": 10,
+              "values": ["2"]
+            }
+          ],
+          "orderBy": [
+            {
+              "fieldName": "name",
+              "direction": 1
+            }
+          ],
+          "groupBy": [
+            {
+              "fieldName": "name",
+              "direction": 2,
+              "aggregates": [
+                { "fieldName": "id", "aggregation": 5 }
+              ]
+            },
+            {
+              "fieldName": "accepted",
+              "direction": 1,
+              "aggregates": []
+            }
+          ],
+          "aggregates": [
+            { "fieldName": "id", "aggregation": 5 }
+          ]
+        }
+        """;
+
+    private const string DotnetLegacyJson = """
+        {
+          "Skip": 10,
+          "Take": 25,
+          "FilterBy": [
+            {
+              "FieldName": "name",
+              "Op": "And",
+              "Relation": "Equals",
+              "Values": ["Ada"]
+            },
+            {
+              "FieldName": "id",
+              "Op": "Or",
+              "Relation": "NotEqual",
+              "Values": ["2"]
+            }
+          ],
+          "OrderBy": [
+            { "FieldName": "name", "Direction": "Ascending" }
+          ],
+          "GroupBy": {
+            "FieldName": "name",
+            "Direction": "Descending",
+            "Aggregates": [
+              { "FieldName": "id", "Aggregation": "Count" }
+            ],
+            "SubGroup": {
+              "FieldName": "accepted",
+              "Direction": "Ascending",
+              "Aggregates": []
+            }
+          },
+          "Aggregates": [
+            { "FieldName": "id", "Aggregation": "Count" }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void ParsesCanonicalV2Json()
+    {
+        var criteria = JsonSerializer.Deserialize<LoadCriteria>(
+            CanonicalJson,
+            ClientFilteringJson.Options
+        )!;
+        AssertCanonical(criteria);
+    }
+
+    [Fact]
+    public void ParsesLegacyDotnetJson()
+    {
+        var criteria = JsonSerializer.Deserialize<LoadCriteria>(
+            DotnetLegacyJson,
+            ClientFilteringJson.Options
+        )!;
+        AssertCanonical(criteria);
+    }
+
+    [Fact]
+    public void WritesCanonicalKeysAndIntEnums()
+    {
+        var criteria = JsonSerializer.Deserialize<LoadCriteria>(
+            CanonicalJson,
+            ClientFilteringJson.Options
+        )!;
+        using var doc = JsonDocument.Parse(
+            JsonSerializer.Serialize(criteria, ClientFilteringJson.Options)
+        );
+        var root = doc.RootElement;
+        root.GetProperty("skip").GetInt32().Should().Be(10);
+        root.GetProperty("filterBy")[0].GetProperty("logicalOperator").GetInt32().Should().Be(1);
+        root.GetProperty("filterBy")[0].GetProperty("op").GetInt32().Should().Be(1);
+        root.GetProperty("groupBy").ValueKind.Should().Be(JsonValueKind.Array);
+        root.GetProperty("groupBy").GetArrayLength().Should().Be(2);
+        root.GetProperty("orderBy")[0].GetProperty("direction").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public void BetweenIsARelationalOperator()
+    {
+        ((int)RelationalOperators.Between)
+            .Should()
+            .Be(13);
+        JsonSerializer
+            .Deserialize<RelationalOperators>("\"EndsWith\"", ClientFilteringJson.Options)
+            .Should()
+            .Be(RelationalOperators.EndsWidth);
+    }
+
+    private static void AssertCanonical(LoadCriteria c)
+    {
+        c.Skip.Should().Be(10);
+        c.Take.Should().Be(25);
+        c.FilterBy.Should().HaveCount(2);
+        var first = c.FilterBy!.First();
+        first.FieldName.Should().Be("name");
+        first.Op.Should().Be(LogicalOperators.And);
+        first.Relation.Should().Be(RelationalOperators.Equals);
+        first.Values.Should().Equal("Ada");
+        var second = c.FilterBy!.Skip(1).First();
+        second.FieldName.Should().Be("id");
+        second.Op.Should().Be(LogicalOperators.Or);
+        second.Relation.Should().Be(RelationalOperators.NotEqual);
+        c.OrderBy!.Single().Direction.Should().Be(OrderDirections.Ascending);
+        c.GroupBy!.FieldName.Should().Be("name");
+        c.GroupBy.Direction.Should().Be(OrderDirections.Descending);
+        c.GroupBy.SubGroup!.FieldName.Should().Be("accepted");
+        c.Aggregates!.Single().Aggregation.Should().Be(Aggregations.Count);
+    }
+}

--- a/javascript/src/lib/aggregatecriteria.ts
+++ b/javascript/src/lib/aggregatecriteria.ts
@@ -1,0 +1,9 @@
+export class AggregateCriteria {
+  public FieldName: string;
+  public Aggregation: number;
+
+  constructor(fieldName = "", aggregation = 0) {
+    this.FieldName = fieldName;
+    this.Aggregation = aggregation;
+  }
+}

--- a/javascript/src/lib/enums.ts
+++ b/javascript/src/lib/enums.ts
@@ -7,6 +7,7 @@ export enum Logic {
   Contains = 6,
   NotContains = 7,
   EndsWidth = 8,
+  EndsWith = 8,
   StartsWith = 9,
   NotEqual = 10,
   NotStartsWith = 11,

--- a/javascript/src/lib/groupcriteria.ts
+++ b/javascript/src/lib/groupcriteria.ts
@@ -1,0 +1,12 @@
+import { OrderDirections } from "./enums";
+import { AggregateCriteria } from "./aggregatecriteria";
+
+export class GroupCriteria {
+  public FieldName: string;
+  public Direction = OrderDirections.Ascending;
+  public Aggregates: AggregateCriteria[] = [];
+
+  constructor(fieldName = "") {
+    this.FieldName = fieldName;
+  }
+}

--- a/javascript/src/lib/json.ts
+++ b/javascript/src/lib/json.ts
@@ -1,0 +1,195 @@
+import { Logic, Operators, OrderDirections } from "./enums";
+import { AggregateCriteria } from "./aggregatecriteria";
+import { FilterCriteria } from "./filtercriteria";
+import { GroupCriteria } from "./groupcriteria";
+import { LoadCriteria } from "./loadcriteria";
+import { OrderCriteria } from "./ordercriteria";
+
+function valueOf(obj: Record<string, unknown>, camel: string, ...aliases: string[]): unknown {
+  const names = [camel, ...aliases];
+  for (const name of names) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (key.toLowerCase() === name.toLowerCase()) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseEnum(value: unknown, names: Record<string, number>, fallback = 0): number {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const asInt = Number.parseInt(value, 10);
+    if (!Number.isNaN(asInt) && String(asInt) === value) {
+      return asInt;
+    }
+    const key = value.toLowerCase().replace(/[_\s]/g, "");
+    if (key in names) {
+      return names[key];
+    }
+  }
+  throw new Error(`Cannot parse enum from ${String(value)}`);
+}
+
+const logicNames: Record<string, number> = {
+  equals: Logic.Equals,
+  lessthan: Logic.LessThan,
+  greaterthan: Logic.GreaterThan,
+  lessthanorequalto: Logic.LessThanOrEqualTo,
+  greaterthanorequalto: Logic.GreaterThanOrEqualTo,
+  contains: Logic.Contains,
+  notcontains: Logic.NotContains,
+  endswith: Logic.EndsWith,
+  endswidth: Logic.EndsWidth,
+  startswith: Logic.StartsWith,
+  notequal: Logic.NotEqual,
+  notstartswith: Logic.NotStartsWith,
+  notendswith: Logic.NotEndsWith,
+  between: Logic.Between,
+};
+
+const operatorNames: Record<string, number> = { and: Operators.And, or: Operators.Or };
+
+const directionNames: Record<string, number> = {
+  notset: OrderDirections.NotSet,
+  ascending: OrderDirections.Ascending,
+  descending: OrderDirections.Descending,
+};
+
+const aggregationNames: Record<string, number> = {
+  sum: 1,
+  average: 2,
+  maximum: 3,
+  minimum: 4,
+  count: 5,
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function groupByFromJson(raw: unknown): GroupCriteria[] | undefined {
+  if (raw == null) {
+    return undefined;
+  }
+  const groups: GroupCriteria[] = [];
+  const add = (node: unknown): void => {
+    if (node == null) {
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(add);
+      return;
+    }
+    if (typeof node === "object") {
+      const map = asRecord(node);
+      const group = new GroupCriteria(String(valueOf(map, "fieldName") ?? ""));
+      group.Direction = parseEnum(
+        valueOf(map, "direction", "directions"),
+        directionNames,
+        OrderDirections.Ascending
+      );
+      group.Aggregates = asArray(valueOf(map, "aggregates")).map((item) => {
+        const row = asRecord(item);
+        return new AggregateCriteria(
+          String(valueOf(row, "fieldName") ?? ""),
+          parseEnum(valueOf(row, "aggregation"), aggregationNames)
+        );
+      });
+      groups.push(group);
+      add(valueOf(map, "subGroup"));
+    }
+  };
+  add(raw);
+  return groups;
+}
+
+export function loadCriteriaFromJson(json: unknown): LoadCriteria {
+  const map = asRecord(json);
+  const criteria = new LoadCriteria();
+  const skip = valueOf(map, "skip");
+  const take = valueOf(map, "take");
+  if (typeof skip === "number") {
+    criteria.Skip = skip;
+  }
+  if (typeof take === "number") {
+    criteria.Take = take;
+  }
+  criteria.FilterBy = asArray(valueOf(map, "filterBy")).map((item) => {
+    const row = asRecord(item);
+    const filter = new FilterCriteria();
+    filter.FieldName = String(valueOf(row, "fieldName") ?? "");
+    filter.Op = parseEnum(valueOf(row, "op") ?? 1, operatorNames, Operators.And);
+    filter.LogicalOperator = parseEnum(
+      valueOf(row, "logicalOperator", "relation"),
+      logicNames
+    );
+    filter.Values = asArray(valueOf(row, "values")).map((v) =>
+      v == null ? null : String(v)
+    );
+    return filter;
+  });
+  criteria.OrderBy = asArray(valueOf(map, "orderBy")).map((item) => {
+    const row = asRecord(item);
+    const order = new OrderCriteria();
+    order.FieldName = String(valueOf(row, "fieldName") ?? "");
+    order.Direction = parseEnum(
+      valueOf(row, "direction"),
+      directionNames,
+      OrderDirections.Ascending
+    );
+    return order;
+  });
+  criteria.GroupBy = groupByFromJson(valueOf(map, "groupBy"));
+  const aggregates = valueOf(map, "aggregates");
+  criteria.Aggregates =
+    aggregates == null
+      ? undefined
+      : asArray(aggregates).map((item) => {
+          const row = asRecord(item);
+          return new AggregateCriteria(
+            String(valueOf(row, "fieldName") ?? ""),
+            parseEnum(valueOf(row, "aggregation"), aggregationNames)
+          );
+        });
+  return criteria;
+}
+
+export function loadCriteriaToJson(criteria: LoadCriteria): Record<string, unknown> {
+  return {
+    skip: criteria.Skip ?? null,
+    take: criteria.Take ?? null,
+    filterBy: criteria.FilterBy.map((filter) => ({
+      fieldName: filter.FieldName,
+      op: filter.Op,
+      logicalOperator: filter.LogicalOperator,
+      values: filter.Values,
+    })),
+    orderBy: criteria.OrderBy.map((order) => ({
+      fieldName: order.FieldName,
+      direction: order.Direction,
+    })),
+    groupBy: criteria.GroupBy?.map((group) => ({
+      fieldName: group.FieldName,
+      direction: group.Direction,
+      aggregates: group.Aggregates.map((agg) => ({
+        fieldName: agg.FieldName,
+        aggregation: agg.Aggregation,
+      })),
+    })),
+    aggregates: criteria.Aggregates?.map((agg) => ({
+      fieldName: agg.FieldName,
+      aggregation: agg.Aggregation,
+    })),
+  };
+}

--- a/javascript/src/lib/loadcriteria.ts
+++ b/javascript/src/lib/loadcriteria.ts
@@ -1,5 +1,7 @@
 import { FilterCriteria } from "./filtercriteria";
 import { OrderCriteria } from "./ordercriteria";
+import { GroupCriteria } from "./groupcriteria";
+import { AggregateCriteria } from "./aggregatecriteria";
 
 export class LoadCriteria {
   /// <summary>
@@ -18,4 +20,6 @@ export class LoadCriteria {
   /// Any ordering criteria to apply to the results
   /// </summary>
   public OrderBy: OrderCriteria[] = [];
+  public GroupBy?: GroupCriteria[];
+  public Aggregates?: AggregateCriteria[];
 }

--- a/javascript/src/public-api.ts
+++ b/javascript/src/public-api.ts
@@ -2,3 +2,6 @@ export * from "./lib/enums";
 export * from "./lib/filtercriteria";
 export * from "./lib/loadcriteria";
 export * from "./lib/ordercriteria";
+export * from "./lib/groupcriteria";
+export * from "./lib/aggregatecriteria";
+export * from "./lib/json";

--- a/javascript/test/contract.test.ts
+++ b/javascript/test/contract.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadCriteriaFromJson, loadCriteriaToJson } from "../src/lib/json.ts";
+import { Logic } from "../src/lib/enums.ts";
+import { LoadCriteria } from "../src/lib/loadcriteria.ts";
+
+const canonicalJson = {
+  skip: 10,
+  take: 25,
+  filterBy: [
+    { fieldName: "name", op: 1, logicalOperator: 1, values: ["Ada"] },
+    { fieldName: "id", op: 2, logicalOperator: 10, values: ["2"] },
+  ],
+  orderBy: [{ fieldName: "name", direction: 1 }],
+  groupBy: [
+    {
+      fieldName: "name",
+      direction: 2,
+      aggregates: [{ fieldName: "id", aggregation: 5 }],
+    },
+    { fieldName: "accepted", direction: 1, aggregates: [] },
+  ],
+  aggregates: [{ fieldName: "id", aggregation: 5 }],
+};
+
+const dotnetLegacyJson = {
+  Skip: 10,
+  Take: 25,
+  FilterBy: [
+    { FieldName: "name", Op: "And", Relation: "Equals", Values: ["Ada"] },
+    { FieldName: "id", Op: "Or", Relation: "NotEqual", Values: ["2"] },
+  ],
+  OrderBy: [{ FieldName: "name", Direction: "Ascending" }],
+  GroupBy: {
+    FieldName: "name",
+    Direction: "Descending",
+    Aggregates: [{ FieldName: "id", Aggregation: "Count" }],
+    SubGroup: {
+      FieldName: "accepted",
+      Direction: "Ascending",
+      Aggregates: [],
+    },
+  },
+  Aggregates: [{ FieldName: "id", Aggregation: "Count" }],
+};
+
+function assertCanonical(criteria: LoadCriteria): void {
+  assert.equal(criteria.Skip, 10);
+  assert.equal(criteria.Take, 25);
+  assert.equal(criteria.FilterBy.length, 2);
+  assert.equal(criteria.FilterBy[0].FieldName, "name");
+  assert.equal(criteria.FilterBy[0].LogicalOperator, Logic.Equals);
+  assert.equal(criteria.FilterBy[1].Op, 2);
+  assert.equal(criteria.GroupBy?.length, 2);
+  assert.equal(criteria.GroupBy?.[0].FieldName, "name");
+  assert.equal(criteria.GroupBy?.[1].FieldName, "accepted");
+  assert.equal(criteria.Aggregates?.[0].Aggregation, 5);
+}
+
+test("parses canonical V2 JSON", () => {
+  assertCanonical(loadCriteriaFromJson(canonicalJson));
+});
+
+test("parses legacy .NET JSON", () => {
+  assertCanonical(loadCriteriaFromJson(dotnetLegacyJson));
+});
+
+test("toJSON emits canonical keys and int enums", () => {
+  const json = loadCriteriaToJson(loadCriteriaFromJson(canonicalJson));
+  assert.equal(
+    (json.filterBy as { logicalOperator: number }[])[0].logicalOperator,
+    1
+  );
+  assert.ok(Array.isArray(json.groupBy));
+  assert.equal((json.groupBy as unknown[]).length, 2);
+  assert.equal((json.orderBy as { direction: number }[])[0].direction, 1);
+});


### PR DESCRIPTION
## Summary
- One V2 wire contract: camelCase keys, integer enums, `logicalOperator`, `groupBy` as an array.
- Dart, .NET, and JS all **parse** that contract **and** the legacy .NET shape (PascalCase, string enums, `Relation`, nested `SubGroup`).
- .NET `GroupBy` still uses nested `SubGroup` in the C# model; JSON reads/writes an array. `Between` is now a relational operator (13). Use `ClientFilteringJson.Options` for camelCase + flexible enums.
- JS gains `GroupBy`/`Aggregates` plus `loadCriteriaFromJson` / `loadCriteriaToJson`.

Closes #35

## Test plan
- [x] `flutter test` in `client_filtering/` (32 passed)
- [x] `dart analyze` in `client_filtering/` (no issues)
- [x] `DOTNET_ROLL_FORWARD=LatestMajor dotnet test` (11 passed)
- [x] `npx tsx --test javascript/test/contract.test.ts` (3 passed)